### PR TITLE
feat(aura-post): Medium-ready SVG assets + extended converter

### DIFF
--- a/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/architecture.svg
+++ b/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/architecture.svg
@@ -1,0 +1,152 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 880" font-family="Inter, system-ui, sans-serif">
+  <defs>
+    <linearGradient id="purp" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#A78BFA"/>
+      <stop offset="1" stop-color="#7C3AED"/>
+    </linearGradient>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#9CA3AF"/>
+    </marker>
+  </defs>
+
+  <rect width="1200" height="880" fill="#f9fafb"/>
+
+  <text x="60" y="48" font-size="13" font-weight="700" fill="#7C3AED" letter-spacing="2">AURA ARCHITECTURE</text>
+  <text x="60" y="72" font-size="14" fill="#6B7280">Clients → Gateway middleware + core → Providers, with optional Postgres / Redis / Prometheus</text>
+
+  <!-- Clients row -->
+  <text x="60" y="118" font-size="11" font-weight="700" fill="#6B7280" letter-spacing="1.5">CLIENTS</text>
+  <g transform="translate(60,130)">
+    <g>
+      <rect width="340" height="68" rx="12" fill="white" stroke="#E5E7EB"/>
+      <text x="170" y="32" text-anchor="middle" font-size="15" font-weight="700" fill="#0a0a0a">Chat UI</text>
+      <text x="170" y="52" text-anchor="middle" font-size="12" fill="#6B7280">user-facing apps · apps/chat</text>
+    </g>
+    <g transform="translate(360,0)">
+      <rect width="340" height="68" rx="12" fill="white" stroke="#E5E7EB"/>
+      <text x="170" y="32" text-anchor="middle" font-size="15" font-weight="700" fill="#0a0a0a">Agents</text>
+      <text x="170" y="52" text-anchor="middle" font-size="12" fill="#6B7280">tool-using workflows · agentic loops</text>
+    </g>
+    <g transform="translate(720,0)">
+      <rect width="340" height="68" rx="12" fill="white" stroke="#E5E7EB"/>
+      <text x="170" y="32" text-anchor="middle" font-size="15" font-weight="700" fill="#0a0a0a">Applications</text>
+      <text x="170" y="52" text-anchor="middle" font-size="12" fill="#6B7280">APIs · workers · CLIs · SDKs</text>
+    </g>
+  </g>
+
+  <!-- Arrows down -->
+  <line x1="230" y1="206" x2="230" y2="234" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="600" y1="206" x2="600" y2="234" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="970" y1="206" x2="970" y2="234" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Gateway block (middleware + core) -->
+  <g transform="translate(60,244)">
+    <rect width="900" height="296" rx="16" fill="url(#purp)" opacity="0.08"/>
+    <rect width="900" height="296" rx="16" fill="none" stroke="#7C3AED" stroke-opacity="0.35"/>
+    <text x="20" y="28" font-size="11" font-weight="700" fill="#7C3AED" letter-spacing="1.5">AURA GATEWAY</text>
+
+    <!-- Middleware row -->
+    <text x="20" y="58" font-size="11" font-weight="600" fill="#6B7280" letter-spacing="1.5">MIDDLEWARE</text>
+    <g transform="translate(20,72)">
+      <g>
+        <rect width="166" height="58" rx="10" fill="white" stroke="#E5E7EB"/>
+        <text x="83" y="26" text-anchor="middle" font-size="13" font-weight="700" fill="#0a0a0a">Auth</text>
+        <text x="83" y="44" text-anchor="middle" font-size="11" fill="#6B7280">bearer + scopes</text>
+      </g>
+      <g transform="translate(174,0)">
+        <rect width="166" height="58" rx="10" fill="white" stroke="#E5E7EB"/>
+        <text x="83" y="26" text-anchor="middle" font-size="13" font-weight="700" fill="#0a0a0a">Rate limiter</text>
+        <text x="83" y="44" text-anchor="middle" font-size="11" fill="#6B7280">Redis bucket</text>
+      </g>
+      <g transform="translate(348,0)">
+        <rect width="166" height="58" rx="10" fill="white" stroke="#E5E7EB"/>
+        <text x="83" y="26" text-anchor="middle" font-size="13" font-weight="700" fill="#0a0a0a">Response cache</text>
+        <text x="83" y="44" text-anchor="middle" font-size="11" fill="#6B7280">SHA256 · TTL</text>
+      </g>
+      <g transform="translate(522,0)">
+        <rect width="166" height="58" rx="10" fill="white" stroke="#E5E7EB"/>
+        <text x="83" y="26" text-anchor="middle" font-size="13" font-weight="700" fill="#0a0a0a">Compression</text>
+        <text x="83" y="44" text-anchor="middle" font-size="11" fill="#6B7280">TOON · AISP</text>
+      </g>
+      <g transform="translate(696,0)">
+        <rect width="166" height="58" rx="10" fill="white" stroke="#E5E7EB"/>
+        <text x="83" y="26" text-anchor="middle" font-size="13" font-weight="700" fill="#0a0a0a">Logger</text>
+        <text x="83" y="44" text-anchor="middle" font-size="11" fill="#6B7280">async → Postgres</text>
+      </g>
+    </g>
+
+    <!-- Core row -->
+    <text x="20" y="172" font-size="11" font-weight="600" fill="#6B7280" letter-spacing="1.5">CORE</text>
+    <g transform="translate(20,186)">
+      <g>
+        <rect width="280" height="86" rx="12" fill="#7C3AED"/>
+        <text x="140" y="32" text-anchor="middle" font-size="14" font-weight="700" fill="white">Provider Registry</text>
+        <text x="140" y="52" text-anchor="middle" font-size="11" fill="#EDE9FE">model → provider</text>
+        <text x="140" y="70" text-anchor="middle" font-size="11" fill="#EDE9FE">trait adapters</text>
+      </g>
+      <g transform="translate(292,0)">
+        <rect width="280" height="86" rx="12" fill="#7C3AED"/>
+        <text x="140" y="32" text-anchor="middle" font-size="14" font-weight="700" fill="white">Cost Calculator</text>
+        <text x="140" y="52" text-anchor="middle" font-size="11" fill="#EDE9FE">per-model pricing</text>
+        <text x="140" y="70" text-anchor="middle" font-size="11" fill="#EDE9FE">input · output · cached · reasoning</text>
+      </g>
+      <g transform="translate(584,0)">
+        <rect width="276" height="86" rx="12" fill="#7C3AED"/>
+        <text x="138" y="32" text-anchor="middle" font-size="14" font-weight="700" fill="white">Response Enrichment</text>
+        <text x="138" y="52" text-anchor="middle" font-size="11" fill="#EDE9FE">cost_usd · latency_ms</text>
+        <text x="138" y="70" text-anchor="middle" font-size="11" fill="#EDE9FE">agentic{...}</text>
+      </g>
+    </g>
+  </g>
+
+  <!-- Storage column on the right -->
+  <text x="990" y="270" font-size="11" font-weight="700" fill="#6B7280" letter-spacing="1.5">STORAGE</text>
+  <g transform="translate(990,284)">
+    <g>
+      <rect width="170" height="80" rx="12" fill="white" stroke="#E5E7EB"/>
+      <text x="85" y="32" text-anchor="middle" font-size="14" font-weight="700" fill="#0a0a0a">PostgreSQL</text>
+      <text x="85" y="52" text-anchor="middle" font-size="11" fill="#6B7280">logs · orgs · keys</text>
+      <text x="85" y="68" text-anchor="middle" font-size="11" fill="#6B7280">users (optional)</text>
+    </g>
+    <g transform="translate(0,90)">
+      <rect width="170" height="80" rx="12" fill="white" stroke="#E5E7EB"/>
+      <text x="85" y="32" text-anchor="middle" font-size="14" font-weight="700" fill="#0a0a0a">Redis</text>
+      <text x="85" y="52" text-anchor="middle" font-size="11" fill="#6B7280">rate limits</text>
+      <text x="85" y="68" text-anchor="middle" font-size="11" fill="#6B7280">response cache</text>
+    </g>
+    <g transform="translate(0,180)">
+      <rect width="170" height="80" rx="12" fill="white" stroke="#E5E7EB"/>
+      <text x="85" y="32" text-anchor="middle" font-size="14" font-weight="700" fill="#0a0a0a">Prometheus</text>
+      <text x="85" y="52" text-anchor="middle" font-size="11" fill="#6B7280">/metrics</text>
+      <text x="85" y="68" text-anchor="middle" font-size="11" fill="#6B7280">endpoint</text>
+    </g>
+  </g>
+
+  <!-- Arrow from gateway to providers -->
+  <line x1="500" y1="544" x2="500" y2="582" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Providers row -->
+  <text x="60" y="610" font-size="11" font-weight="700" fill="#6B7280" letter-spacing="1.5">PROVIDERS</text>
+  <g transform="translate(60,624)" font-size="12">
+    <g><rect width="155" height="62" rx="10" fill="white" stroke="#E5E7EB"/><text x="77.5" y="28" text-anchor="middle" font-weight="700" fill="#0a0a0a">OpenAI</text><text x="77.5" y="48" text-anchor="middle" fill="#6B7280">GPT-5 · o-series</text></g>
+    <g transform="translate(163,0)"><rect width="155" height="62" rx="10" fill="white" stroke="#E5E7EB"/><text x="77.5" y="28" text-anchor="middle" font-weight="700" fill="#0a0a0a">Anthropic</text><text x="77.5" y="48" text-anchor="middle" fill="#6B7280">Claude 4.5 · 3.5</text></g>
+    <g transform="translate(326,0)"><rect width="155" height="62" rx="10" fill="white" stroke="#E5E7EB"/><text x="77.5" y="28" text-anchor="middle" font-weight="700" fill="#0a0a0a">Google</text><text x="77.5" y="48" text-anchor="middle" fill="#6B7280">Gemini 3 · 2.5</text></g>
+    <g transform="translate(489,0)"><rect width="155" height="62" rx="10" fill="white" stroke="#E5E7EB"/><text x="77.5" y="28" text-anchor="middle" font-weight="700" fill="#0a0a0a">Mistral</text><text x="77.5" y="48" text-anchor="middle" fill="#6B7280">OAI-compatible</text></g>
+    <g transform="translate(652,0)"><rect width="155" height="62" rx="10" fill="white" stroke="#E5E7EB"/><text x="77.5" y="28" text-anchor="middle" font-weight="700" fill="#0a0a0a">Ollama</text><text x="77.5" y="48" text-anchor="middle" fill="#6B7280">local models</text></g>
+    <g transform="translate(815,0)"><rect width="155" height="62" rx="10" fill="white" stroke="#E5E7EB"/><text x="77.5" y="28" text-anchor="middle" font-weight="700" fill="#0a0a0a">Bedrock</text><text x="77.5" y="48" text-anchor="middle" fill="#6B7280">AWS SigV4</text></g>
+    <g transform="translate(978,0)"><rect width="155" height="62" rx="10" fill="white" stroke="#E5E7EB"/><text x="77.5" y="28" text-anchor="middle" font-weight="700" fill="#0a0a0a">HuggingFace</text><text x="77.5" y="48" text-anchor="middle" fill="#6B7280">TGI endpoints</text></g>
+  </g>
+
+  <!-- Footer caption -->
+  <text x="60" y="752" font-size="13" fill="#374151">
+    <tspan font-weight="700" fill="#0a0a0a">One endpoint, every provider.</tspan>  POST /v1/responses → enriched with cost_usd, latency_ms, and an agentic{} block on the way back.
+  </text>
+  <text x="60" y="784" font-size="12" fill="#6B7280">Resolution happens from the model name. No YAML routing config. Provider registry owns it.</text>
+
+  <!-- Brand chip -->
+  <g transform="translate(60,832)">
+    <rect width="180" height="28" rx="14" fill="#7C3AED"/>
+    <text x="90" y="19" text-anchor="middle" font-size="12" font-weight="700" fill="white">aura-llm.dev</text>
+  </g>
+  <text x="1140" y="852" text-anchor="end" font-size="11" fill="#9CA3AF">Source: github.com/UmaiTech/aura-llm-gateway · v0.9</text>
+</svg>

--- a/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/aura-hero.svg
+++ b/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/aura-hero.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" font-family="Inter, system-ui, sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1E1B4B"/>
+      <stop offset="1" stop-color="#0a0a0a"/>
+    </linearGradient>
+    <linearGradient id="aura" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#A78BFA"/>
+      <stop offset="0.5" stop-color="#8B5CF6"/>
+      <stop offset="1" stop-color="#7C3AED"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#8B5CF6" stop-opacity="0.6"/>
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <!-- Decorative orbs -->
+  <circle cx="180" cy="120" r="220" fill="url(#glow)"/>
+  <circle cx="1050" cy="540" r="240" fill="url(#glow)" opacity="0.7"/>
+
+  <!-- Eyebrow -->
+  <g transform="translate(80,108)">
+    <rect width="220" height="32" rx="16" fill="#7C3AED"/>
+    <text x="110" y="21" text-anchor="middle" font-size="12" font-weight="700" fill="white" letter-spacing="3">AGENTIC DEV DAYS 2026</text>
+  </g>
+
+  <!-- Title -->
+  <text x="80" y="220" font-size="72" font-weight="800" fill="white" letter-spacing="-2">Building </text>
+  <text x="378" y="220" font-size="72" font-weight="800" fill="url(#aura)" letter-spacing="-2">Aura</text>
+  <text x="80" y="290" font-size="42" font-weight="700" fill="white" opacity="0.92" letter-spacing="-1">An Agentic LLM Gateway in Rust</text>
+
+  <!-- Subhead -->
+  <text x="80" y="342" font-size="20" fill="#A78BFA" font-style="italic">Vibe engineering taught me Rust. Claude Code carried the rest.</text>
+
+  <!-- Feature chips -->
+  <g transform="translate(80,400)" font-size="13" font-weight="700">
+    <g>
+      <rect width="208" height="40" rx="20" fill="white" fill-opacity="0.08" stroke="#A78BFA" stroke-opacity="0.4"/>
+      <text x="104" y="25" text-anchor="middle" fill="white">Open Responses API</text>
+    </g>
+    <g transform="translate(220,0)">
+      <rect width="148" height="40" rx="20" fill="white" fill-opacity="0.08" stroke="#A78BFA" stroke-opacity="0.4"/>
+      <text x="74" y="25" text-anchor="middle" fill="white">7 providers</text>
+    </g>
+    <g transform="translate(380,0)">
+      <rect width="200" height="40" rx="20" fill="white" fill-opacity="0.08" stroke="#A78BFA" stroke-opacity="0.4"/>
+      <text x="100" y="25" text-anchor="middle" fill="white">cost on every response</text>
+    </g>
+    <g transform="translate(592,0)">
+      <rect width="184" height="40" rx="20" fill="white" fill-opacity="0.08" stroke="#A78BFA" stroke-opacity="0.4"/>
+      <text x="92" y="25" text-anchor="middle" fill="white">Rust · Axum · Tokio</text>
+    </g>
+  </g>
+
+  <!-- Author + URL -->
+  <g transform="translate(80,500)">
+    <circle cx="22" cy="22" r="22" fill="#7C3AED"/>
+    <text x="22" y="29" text-anchor="middle" font-size="18" font-weight="700" fill="white">M</text>
+    <text x="58" y="20" font-size="16" font-weight="700" fill="white">Marcus Elwin</text>
+    <text x="58" y="40" font-size="13" fill="#A78BFA">umai-tech.com · @MarcusElwin</text>
+  </g>
+
+  <!-- URL pill bottom-right -->
+  <g transform="translate(880,540)">
+    <rect width="240" height="44" rx="22" fill="#7C3AED"/>
+    <text x="120" y="28" text-anchor="middle" font-size="16" font-weight="700" fill="white">aura-llm.dev</text>
+  </g>
+
+  <!-- Japanese mark (umai) -->
+  <text x="1120" y="120" font-size="64" font-weight="700" fill="#7C3AED" opacity="0.4" text-anchor="end">うまい</text>
+</svg>

--- a/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/crates.svg
+++ b/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/crates.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 760" font-family="Inter, system-ui, sans-serif">
+  <rect width="1200" height="760" fill="#f9fafb"/>
+
+  <text x="40" y="44" font-size="13" font-weight="700" fill="#7C3AED" letter-spacing="2">AURA · 4-CRATE CARGO WORKSPACE</text>
+  <text x="40" y="70" font-size="20" font-weight="700" fill="#0a0a0a">Each crate has one responsibility, with explicit dependency direction</text>
+  <text x="40" y="92" font-size="13" fill="#6B7280">Nothing exotic — Axum 0.8, Tokio, SQLx, Redis, Reqwest. The interesting parts live above the stack.</text>
+
+  <!-- Row 1: aura-types | aura-db -->
+  <g transform="translate(40,120)">
+    <rect width="555" height="280" rx="14" fill="white" stroke="#E5E7EB"/>
+    <rect width="4" height="280" rx="2" fill="#7C3AED"/>
+    <text x="24" y="36" font-size="11" font-weight="700" fill="#7C3AED" letter-spacing="1.5">FOUNDATION · TYPES</text>
+    <text x="24" y="64" font-size="22" font-weight="700" fill="#0a0a0a" font-family="JetBrains Mono, monospace">aura-types</text>
+    <text x="24" y="86" font-size="13" fill="#374151">Open Responses API types</text>
+    <text x="24" y="120" font-size="12" fill="#6B7280">Shared type system for the Open Responses spec —</text>
+    <text x="24" y="138" font-size="12" fill="#6B7280">request, response, items, events.</text>
+    <text x="24" y="156" font-size="12" fill="#6B7280">60+ tests catch provider drift at compile time.</text>
+
+    <text x="24" y="194" font-size="11" font-weight="700" fill="#9CA3AF" letter-spacing="1">MODULES</text>
+    <text x="24" y="214" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">item.rs · response.rs · stream.rs</text>
+    <text x="24" y="232" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">compression.rs · consistency.rs</text>
+    <text x="24" y="250" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">validation.rs</text>
+
+    <text x="380" y="194" font-size="11" font-weight="700" fill="#9CA3AF" letter-spacing="1">DEPS</text>
+    <text x="380" y="214" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">serde</text>
+    <text x="380" y="232" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">thiserror</text>
+  </g>
+
+  <g transform="translate(605,120)">
+    <rect width="555" height="280" rx="14" fill="white" stroke="#E5E7EB"/>
+    <rect width="4" height="280" rx="2" fill="#A78BFA"/>
+    <text x="24" y="36" font-size="11" font-weight="700" fill="#A78BFA" letter-spacing="1.5">PERSISTENCE · OPTIONAL</text>
+    <text x="24" y="64" font-size="22" font-weight="700" fill="#0a0a0a" font-family="JetBrains Mono, monospace">aura-db</text>
+    <text x="24" y="86" font-size="13" fill="#374151">Database models and migrations</text>
+    <text x="24" y="120" font-size="12" fill="#6B7280">SQLx models, query layer, migration set for Postgres.</text>
+    <text x="24" y="138" font-size="12" fill="#6B7280">Org → team → project → end-user hierarchy lives here.</text>
+    <text x="24" y="156" font-size="12" fill="#6B7280">Optional — Aura runs stateless without it.</text>
+
+    <text x="24" y="194" font-size="11" font-weight="700" fill="#9CA3AF" letter-spacing="1">MODULES</text>
+    <text x="24" y="214" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">models.rs · repo.rs</text>
+    <text x="24" y="232" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">pool.rs · error.rs</text>
+
+    <text x="380" y="194" font-size="11" font-weight="700" fill="#9CA3AF" letter-spacing="1">DEPS</text>
+    <text x="380" y="214" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">sqlx (Postgres)</text>
+    <text x="380" y="232" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">aura-types</text>
+  </g>
+
+  <!-- Row 2: aura-core | aura-proxy -->
+  <g transform="translate(40,420)">
+    <rect width="555" height="280" rx="14" fill="white" stroke="#E5E7EB"/>
+    <rect width="4" height="280" rx="2" fill="#7C3AED"/>
+    <text x="24" y="36" font-size="11" font-weight="700" fill="#7C3AED" letter-spacing="1.5">BUSINESS LOGIC</text>
+    <text x="24" y="64" font-size="22" font-weight="700" fill="#0a0a0a" font-family="JetBrains Mono, monospace">aura-core</text>
+    <text x="24" y="86" font-size="13" fill="#374151">Provider adapters, routing, cost, compression</text>
+    <text x="24" y="120" font-size="12" fill="#6B7280">Provider trait + 7 per-vendor adapters, cost</text>
+    <text x="24" y="138" font-size="12" fill="#6B7280">calculator, rate limiter, response cache, prompt</text>
+    <text x="24" y="156" font-size="12" fill="#6B7280">compression, AES-256-GCM crypto.</text>
+
+    <text x="24" y="194" font-size="11" font-weight="700" fill="#9CA3AF" letter-spacing="1">MODULES</text>
+    <text x="24" y="214" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">provider/ · router/ · cost.rs</text>
+    <text x="24" y="232" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">cache.rs · rate_limit.rs</text>
+    <text x="24" y="250" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">compression/ · crypto.rs · metrics.rs</text>
+
+    <text x="380" y="194" font-size="11" font-weight="700" fill="#9CA3AF" letter-spacing="1">DEPS</text>
+    <text x="380" y="214" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">reqwest · redis</text>
+    <text x="380" y="232" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">tokio · aura-types</text>
+    <text x="380" y="250" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">aura-db</text>
+  </g>
+
+  <g transform="translate(605,420)">
+    <rect width="555" height="280" rx="14" fill="white" stroke="#E5E7EB"/>
+    <rect width="4" height="280" rx="2" fill="#A78BFA"/>
+    <text x="24" y="36" font-size="11" font-weight="700" fill="#A78BFA" letter-spacing="1.5">HTTP LAYER · BINARY</text>
+    <text x="24" y="64" font-size="22" font-weight="700" fill="#0a0a0a" font-family="JetBrains Mono, monospace">aura-proxy</text>
+    <text x="24" y="86" font-size="13" fill="#374151">Axum binary, middleware, routes</text>
+    <text x="24" y="120" font-size="12" fill="#6B7280">The actual server. Route handlers, middleware stack,</text>
+    <text x="24" y="138" font-size="12" fill="#6B7280">application state, /metrics endpoint.</text>
+    <text x="24" y="156" font-size="12" fill="#6B7280">The only crate that produces a binary.</text>
+
+    <text x="24" y="194" font-size="11" font-weight="700" fill="#9CA3AF" letter-spacing="1">MODULES</text>
+    <text x="24" y="214" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">main.rs · routes/</text>
+
+    <text x="380" y="194" font-size="11" font-weight="700" fill="#9CA3AF" letter-spacing="1">DEPS</text>
+    <text x="380" y="214" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">axum · tower-http</text>
+    <text x="380" y="232" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">aura-types · aura-core</text>
+    <text x="380" y="250" font-size="12" fill="#374151" font-family="JetBrains Mono, monospace">aura-db</text>
+  </g>
+
+  <!-- Footer stack chips -->
+  <g transform="translate(40,724)" font-size="11">
+    <text fill="#6B7280" font-weight="700" letter-spacing="1">STACK</text>
+    <g transform="translate(56,-12)">
+      <rect width="80" height="20" rx="10" fill="#EDE9FE"/><text x="40" y="14" text-anchor="middle" fill="#7C3AED" font-weight="700">Axum 0.8</text>
+    </g>
+    <g transform="translate(146,-12)">
+      <rect width="60" height="20" rx="10" fill="#EDE9FE"/><text x="30" y="14" text-anchor="middle" fill="#7C3AED" font-weight="700">Tokio</text>
+    </g>
+    <g transform="translate(216,-12)">
+      <rect width="60" height="20" rx="10" fill="#EDE9FE"/><text x="30" y="14" text-anchor="middle" fill="#7C3AED" font-weight="700">SQLx</text>
+    </g>
+    <g transform="translate(286,-12)">
+      <rect width="60" height="20" rx="10" fill="#EDE9FE"/><text x="30" y="14" text-anchor="middle" fill="#7C3AED" font-weight="700">Redis</text>
+    </g>
+    <g transform="translate(356,-12)">
+      <rect width="76" height="20" rx="10" fill="#EDE9FE"/><text x="38" y="14" text-anchor="middle" fill="#7C3AED" font-weight="700">Reqwest</text>
+    </g>
+  </g>
+</svg>

--- a/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/lessons.svg
+++ b/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/lessons.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 760" font-family="Inter, system-ui, sans-serif">
+  <rect width="1200" height="760" fill="#f9fafb"/>
+
+  <text x="40" y="44" font-size="13" font-weight="700" fill="#7C3AED" letter-spacing="2">WHAT I'D TELL PAST-ME</text>
+  <text x="40" y="76" font-size="24" font-weight="700" fill="#0a0a0a">Six things I learned the hard way</text>
+  <text x="40" y="100" font-size="13" fill="#6B7280">Building infrastructure that sits in front of every LLM call your product makes — lessons that would have saved weeks.</text>
+
+  <!-- 3 columns × 2 rows. Card 360w × 280h. -->
+  <!-- Row 1 -->
+  <g transform="translate(40,140)">
+    <rect width="360" height="280" rx="14" fill="white" stroke="#E5E7EB"/>
+    <text x="20" y="64" font-size="48" font-weight="700" fill="#7C3AED" font-family="JetBrains Mono, monospace">#1</text>
+    <text x="20" y="108" font-size="16" font-weight="700" fill="#0a0a0a">Pick languages by latency</text>
+    <text x="20" y="128" font-size="16" font-weight="700" fill="#0a0a0a">budget, not hype</text>
+    <text x="20" y="166" font-size="13" fill="#374151">If your overhead budget is under 10 ms,</text>
+    <text x="20" y="184" font-size="13" fill="#374151">Rust earns its place. Anywhere else, ship in</text>
+    <text x="20" y="202" font-size="13" fill="#374151">what your team already knows.</text>
+    <text x="20" y="240" font-size="13" fill="#7C3AED" font-style="italic" font-weight="700">Rust is not a personality.</text>
+  </g>
+
+  <g transform="translate(420,140)">
+    <rect width="360" height="280" rx="14" fill="white" stroke="#E5E7EB"/>
+    <text x="20" y="64" font-size="48" font-weight="700" fill="#7C3AED" font-family="JetBrains Mono, monospace">#2</text>
+    <text x="20" y="108" font-size="16" font-weight="700" fill="#0a0a0a">Observability first,</text>
+    <text x="20" y="128" font-size="16" font-weight="700" fill="#0a0a0a">features second</text>
+    <text x="20" y="166" font-size="13" fill="#374151">OpenTelemetry from day one.</text>
+    <text x="20" y="184" font-size="13" fill="#374151">You can't fix what you can't see,</text>
+    <text x="20" y="202" font-size="13" fill="#374151">and an LLM gateway is the worst</text>
+    <text x="20" y="220" font-size="13" fill="#374151">place to be flying blind.</text>
+  </g>
+
+  <g transform="translate(800,140)">
+    <rect width="360" height="280" rx="14" fill="white" stroke="#E5E7EB"/>
+    <text x="20" y="64" font-size="48" font-weight="700" fill="#7C3AED" font-family="JetBrains Mono, monospace">#3</text>
+    <text x="20" y="108" font-size="16" font-weight="700" fill="#0a0a0a">Typed provider schemas</text>
+    <text x="20" y="128" font-size="16" font-weight="700" fill="#0a0a0a">save you at 3am</text>
+    <text x="20" y="166" font-size="13" fill="#374151">LLM APIs drift. Strong types catch</text>
+    <text x="20" y="184" font-size="13" fill="#374151">the drift before users do.</text>
+    <text x="20" y="222" font-size="13" fill="#7C3AED" font-style="italic" font-weight="700">This alone justifies a typed</text>
+    <text x="20" y="240" font-size="13" fill="#7C3AED" font-style="italic" font-weight="700">language for this layer.</text>
+  </g>
+
+  <!-- Row 2 -->
+  <g transform="translate(40,440)">
+    <rect width="360" height="280" rx="14" fill="white" stroke="#E5E7EB"/>
+    <text x="20" y="64" font-size="48" font-weight="700" fill="#7C3AED" font-family="JetBrains Mono, monospace">#4</text>
+    <text x="20" y="108" font-size="16" font-weight="700" fill="#0a0a0a">Build fallback chains</text>
+    <text x="20" y="128" font-size="16" font-weight="700" fill="#0a0a0a">before you need them</text>
+    <text x="20" y="166" font-size="13" fill="#374151">Every provider goes down.</text>
+    <text x="20" y="184" font-size="13" fill="#374151">Retry, switch, degrade.</text>
+    <text x="20" y="222" font-size="13" fill="#374151">Table stakes — but most teams</text>
+    <text x="20" y="240" font-size="13" fill="#374151">add it the day after their first outage.</text>
+  </g>
+
+  <g transform="translate(420,440)">
+    <rect width="360" height="280" rx="14" fill="#EDE9FE"/>
+    <text x="20" y="64" font-size="48" font-weight="700" fill="#7C3AED" font-family="JetBrains Mono, monospace">#5</text>
+    <text x="20" y="108" font-size="16" font-weight="700" fill="#0a0a0a">Cost tracking is a</text>
+    <text x="20" y="128" font-size="16" font-weight="700" fill="#0a0a0a">product feature</text>
+    <text x="20" y="166" font-size="13" fill="#374151">Not a nice-to-have. Surface it to users</text>
+    <text x="20" y="184" font-size="13" fill="#374151">and PMs from the start.</text>
+    <text x="20" y="222" font-size="13" fill="#7C3AED" font-weight="700">Cheapest time to add it is at the</text>
+    <text x="20" y="240" font-size="13" fill="#7C3AED" font-weight="700">schema level on day one.</text>
+  </g>
+
+  <g transform="translate(800,440)">
+    <rect width="360" height="280" rx="14" fill="white" stroke="#E5E7EB"/>
+    <text x="20" y="64" font-size="48" font-weight="700" fill="#7C3AED" font-family="JetBrains Mono, monospace">#6</text>
+    <text x="20" y="108" font-size="16" font-weight="700" fill="#0a0a0a">Vibe code prototypes.</text>
+    <text x="20" y="128" font-size="16" font-weight="700" fill="#0a0a0a">Vibe engineer production.</text>
+    <text x="20" y="166" font-size="13" fill="#374151">Different modes. Different rigor.</text>
+    <text x="20" y="184" font-size="13" fill="#374151">Don't confuse them — and don't apologize</text>
+    <text x="20" y="202" font-size="13" fill="#374151">for using AI to do either.</text>
+    <text x="20" y="240" font-size="13" fill="#7C3AED" font-style="italic" font-weight="700">The discipline changes, not the tools.</text>
+  </g>
+</svg>

--- a/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/loadtest.svg
+++ b/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/loadtest.svg
@@ -1,0 +1,119 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 720" font-family="Inter, system-ui, sans-serif">
+  <rect width="1200" height="720" fill="#f9fafb"/>
+
+  <!-- Header -->
+  <text x="60" y="48" font-size="13" font-weight="700" fill="#7C3AED" letter-spacing="2">GATEWAY LOAD TEST · OVERHEAD (ms)</text>
+  <text x="60" y="74" font-size="20" font-weight="700" fill="#0a0a0a">Aura vs the competition — Anthropic Sonnet 4.5, 1,000 requests per scenario</text>
+  <text x="60" y="98" font-size="13" fill="#6B7280">Pure gateway-added latency, provider round-trip subtracted. Lower is better.</text>
+
+  <!-- Legend -->
+  <g transform="translate(60,124)" font-size="12">
+    <g><rect width="14" height="14" rx="3" fill="#7C3AED"/><text x="22" y="11" fill="#0a0a0a" font-weight="700">Aura</text></g>
+    <g transform="translate(80,0)"><rect width="14" height="14" rx="3" fill="#A78BFA"/><text x="22" y="11" fill="#374151">Bifrost</text></g>
+    <g transform="translate(180,0)"><rect width="14" height="14" rx="3" fill="#C4B5FD"/><text x="22" y="11" fill="#374151">Helicone</text></g>
+    <g transform="translate(290,0)"><rect width="14" height="14" rx="3" fill="#FBBF24"/><text x="22" y="11" fill="#374151">Portkey</text></g>
+    <g transform="translate(395,0)"><rect width="14" height="14" rx="3" fill="#F97316"/><text x="22" y="11" fill="#374151">OpenRouter</text></g>
+    <g transform="translate(520,0)"><rect width="14" height="14" rx="3" fill="#EF4444"/><text x="22" y="11" fill="#374151">LiteLLM</text></g>
+  </g>
+
+  <!-- Chart area: x = 5 scenarios, y = 0..280ms -->
+  <!-- Plot area: 80..1140 wide, 180..560 tall. Y scale: 280ms → 380px. -->
+  <g transform="translate(80,180)">
+    <!-- Y axis grid -->
+    <g font-size="11" fill="#9CA3AF">
+      <!-- 0 ms -->
+      <line x1="0" y1="380" x2="1060" y2="380" stroke="#E5E7EB"/>
+      <text x="-8" y="384" text-anchor="end">0</text>
+      <!-- 50 ms -->
+      <line x1="0" y1="312" x2="1060" y2="312" stroke="#E5E7EB" stroke-dasharray="2 4"/>
+      <text x="-8" y="316" text-anchor="end">50</text>
+      <!-- 100 ms -->
+      <line x1="0" y1="244" x2="1060" y2="244" stroke="#E5E7EB" stroke-dasharray="2 4"/>
+      <text x="-8" y="248" text-anchor="end">100</text>
+      <!-- 150 ms -->
+      <line x1="0" y1="176" x2="1060" y2="176" stroke="#E5E7EB" stroke-dasharray="2 4"/>
+      <text x="-8" y="180" text-anchor="end">150</text>
+      <!-- 200 ms -->
+      <line x1="0" y1="108" x2="1060" y2="108" stroke="#E5E7EB" stroke-dasharray="2 4"/>
+      <text x="-8" y="112" text-anchor="end">200</text>
+      <!-- 250 ms -->
+      <line x1="0" y1="40" x2="1060" y2="40" stroke="#E5E7EB" stroke-dasharray="2 4"/>
+      <text x="-8" y="44" text-anchor="end">250</text>
+    </g>
+    <text x="-40" y="200" font-size="11" fill="#6B7280" transform="rotate(-90 -40 200)" text-anchor="middle">overhead (ms)</text>
+
+    <!-- Scenarios: each group ~196 wide. Bars: 6 bars × 22w + 4 gap = 152w. Group center at 100, 296, 492, 688, 884. -->
+    <!-- Bar height: ms * 1.36 (max 250 → 340, leaves headroom under 380). Actually 380px / 280ms = 1.357. Use 1.36. -->
+
+    <!-- Scenario 1: 1 tool call. Aura 4, Bifrost 3, Helicone 6, Portkey 22, OpenRouter 30, LiteLLM 58 -->
+    <g transform="translate(20,0)">
+      <rect x="0"   y="375" width="22" height="5"   fill="#7C3AED"/>
+      <rect x="26"  y="376" width="22" height="4"   fill="#A78BFA"/>
+      <rect x="52"  y="372" width="22" height="8"   fill="#C4B5FD"/>
+      <rect x="78"  y="350" width="22" height="30"  fill="#FBBF24"/>
+      <rect x="104" y="339" width="22" height="41"  fill="#F97316"/>
+      <rect x="130" y="301" width="22" height="79"  fill="#EF4444"/>
+      <text x="76" y="402" text-anchor="middle" font-size="12" font-weight="700" fill="#0a0a0a">1 tool call</text>
+    </g>
+
+    <!-- Scenario 2: 2 tool calls. Aura 6, Bifrost 5, Helicone 9, Portkey 38, OpenRouter 50, LiteLLM 105 -->
+    <g transform="translate(216,0)">
+      <rect x="0"   y="372" width="22" height="8"   fill="#7C3AED"/>
+      <rect x="26"  y="373" width="22" height="7"   fill="#A78BFA"/>
+      <rect x="52"  y="368" width="22" height="12"  fill="#C4B5FD"/>
+      <rect x="78"  y="328" width="22" height="52"  fill="#FBBF24"/>
+      <rect x="104" y="312" width="22" height="68"  fill="#F97316"/>
+      <rect x="130" y="237" width="22" height="143" fill="#EF4444"/>
+      <text x="76" y="402" text-anchor="middle" font-size="12" font-weight="700" fill="#0a0a0a">2 tool calls</text>
+    </g>
+
+    <!-- Scenario 3: 3 tool calls. Aura 8, Bifrost 7, Helicone 12, Portkey 55, OpenRouter 72, LiteLLM 152 -->
+    <g transform="translate(412,0)">
+      <rect x="0"   y="369" width="22" height="11"  fill="#7C3AED"/>
+      <rect x="26"  y="370" width="22" height="10"  fill="#A78BFA"/>
+      <rect x="52"  y="364" width="22" height="16"  fill="#C4B5FD"/>
+      <rect x="78"  y="305" width="22" height="75"  fill="#FBBF24"/>
+      <rect x="104" y="282" width="22" height="98"  fill="#F97316"/>
+      <rect x="130" y="173" width="22" height="207" fill="#EF4444"/>
+      <text x="76" y="402" text-anchor="middle" font-size="12" font-weight="700" fill="#0a0a0a">3 tool calls</text>
+    </g>
+
+    <!-- Scenario 4: 4 tool calls. Aura 10, Bifrost 9, Helicone 15, Portkey 72, OpenRouter 95, LiteLLM 200 -->
+    <g transform="translate(608,0)">
+      <rect x="0"   y="366" width="22" height="14"  fill="#7C3AED"/>
+      <rect x="26"  y="368" width="22" height="12"  fill="#A78BFA"/>
+      <rect x="52"  y="360" width="22" height="20"  fill="#C4B5FD"/>
+      <rect x="78"  y="282" width="22" height="98"  fill="#FBBF24"/>
+      <rect x="104" y="251" width="22" height="129" fill="#F97316"/>
+      <rect x="130" y="108" width="22" height="272" fill="#EF4444"/>
+      <text x="76" y="402" text-anchor="middle" font-size="12" font-weight="700" fill="#0a0a0a">4 tool calls</text>
+    </g>
+
+    <!-- Scenario 5: 5 tool calls. Aura 12, Bifrost 11, Helicone 18, Portkey 90, OpenRouter 118, LiteLLM 250 -->
+    <g transform="translate(804,0)">
+      <rect x="0"   y="364" width="22" height="16"  fill="#7C3AED"/>
+      <rect x="26"  y="365" width="22" height="15"  fill="#A78BFA"/>
+      <rect x="52"  y="356" width="22" height="24"  fill="#C4B5FD"/>
+      <rect x="78"  y="258" width="22" height="122" fill="#FBBF24"/>
+      <rect x="104" y="220" width="22" height="160" fill="#F97316"/>
+      <rect x="130" y="40"  width="22" height="340" fill="#EF4444"/>
+      <text x="76" y="402" text-anchor="middle" font-size="12" font-weight="700" fill="#0a0a0a">5 tool calls</text>
+    </g>
+  </g>
+
+  <!-- Headline numbers strip -->
+  <g transform="translate(60,640)" font-size="12" fill="#374151">
+    <text font-weight="700" fill="#0a0a0a">Aura at 5 tool calls: 12 ms overhead.</text>
+    <text x="240" fill="#374151">Bifrost: 11 ms.</text>
+    <text x="340" fill="#374151">Helicone: 18 ms.</text>
+    <text x="450" fill="#374151">Portkey: 90 ms.</text>
+    <text x="560" fill="#374151">OpenRouter: 118 ms.</text>
+    <text x="700" fill="#EF4444" font-weight="700">LiteLLM: 250 ms.</text>
+  </g>
+  <text x="60" y="678" font-size="11" fill="#9CA3AF" font-style="italic">
+    Numbers are directional placeholders pending the live benchmark run. Harness lives at scripts/bench/ in the aura-llm-gateway repo.
+  </text>
+  <text x="60" y="700" font-size="11" fill="#9CA3AF">
+    Aura · Bifrost · Helicone sit in the Rust tier (single-digit µs to low-double-digit ms). Python/edge gateways live higher.
+  </text>
+</svg>

--- a/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/matrix.svg
+++ b/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/matrix.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 760" font-family="Inter, system-ui, sans-serif">
+  <rect width="1200" height="760" fill="#f9fafb"/>
+
+  <text x="40" y="44" font-size="13" font-weight="700" fill="#7C3AED" letter-spacing="2">LLM GATEWAYS IN 2026</text>
+  <text x="40" y="70" font-size="20" font-weight="700" fill="#0a0a0a">What they're good at, what's missing for agents</text>
+  <text x="40" y="92" font-size="13" fill="#6B7280">Survey of the gateways teams actually reach for when building agentic systems</text>
+
+  <!-- Table: header + 8 rows. Columns: Gateway (180) | Lang (110) | OSS (110) | Strength (380) | Gap (350) -->
+  <g transform="translate(40,120)">
+    <!-- Header -->
+    <rect width="1120" height="40" rx="6" fill="#111827"/>
+    <text x="16"  y="25" font-size="12" font-weight="700" fill="white" letter-spacing="1">GATEWAY</text>
+    <text x="196" y="25" font-size="12" font-weight="700" fill="white" letter-spacing="1">LANGUAGE</text>
+    <text x="316" y="25" font-size="12" font-weight="700" fill="white" letter-spacing="1">OPEN SOURCE</text>
+    <text x="436" y="25" font-size="12" font-weight="700" fill="white" letter-spacing="1">STRENGTH</text>
+    <text x="826" y="25" font-size="12" font-weight="700" fill="white" letter-spacing="1">GAP</text>
+
+    <!-- Row 1: LiteLLM -->
+    <g transform="translate(0,46)">
+      <rect width="1120" height="58" rx="6" fill="white" stroke="#E5E7EB"/>
+      <text x="16"  y="24" font-size="14" font-weight="700" fill="#0a0a0a">LiteLLM</text>
+      <text x="196" y="24" font-size="13" fill="#374151">Python</text>
+      <text x="316" y="24" font-size="13" fill="#374151">Yes</text>
+      <text x="436" y="24" font-size="12" fill="#374151">100+ provider coverage,</text>
+      <text x="436" y="42" font-size="12" fill="#374151">simple router, easy self-host</text>
+      <text x="826" y="24" font-size="12" fill="#6B7280">Chat-completions-shaped;</text>
+      <text x="826" y="42" font-size="12" fill="#6B7280">agentic metadata is bolted on</text>
+    </g>
+
+    <!-- Row 2: Portkey -->
+    <g transform="translate(0,110)">
+      <rect width="1120" height="58" rx="6" fill="white" stroke="#E5E7EB"/>
+      <text x="16"  y="24" font-size="14" font-weight="700" fill="#0a0a0a">Portkey</text>
+      <text x="196" y="24" font-size="13" fill="#374151">Node / TS</text>
+      <text x="316" y="24" font-size="13" fill="#374151">Apache 2.0</text>
+      <text x="436" y="24" font-size="12" fill="#374151">Guardrails, semantic cache,</text>
+      <text x="436" y="42" font-size="12" fill="#374151">prompt mgmt, PII redaction</text>
+      <text x="826" y="24" font-size="12" fill="#6B7280">Cloud-first; self-host</text>
+      <text x="826" y="42" font-size="12" fill="#6B7280">is second-class</text>
+    </g>
+
+    <!-- Row 3: Helicone -->
+    <g transform="translate(0,174)">
+      <rect width="1120" height="58" rx="6" fill="white" stroke="#E5E7EB"/>
+      <text x="16"  y="24" font-size="14" font-weight="700" fill="#0a0a0a">Helicone</text>
+      <text x="196" y="24" font-size="13" fill="#374151">Rust</text>
+      <text x="316" y="24" font-size="13" fill="#374151">Yes</text>
+      <text x="436" y="24" font-size="12" fill="#374151">Observability-first,</text>
+      <text x="436" y="42" font-size="12" fill="#374151">edge-friendly, Rust speed</text>
+      <text x="826" y="24" font-size="12" fill="#6B7280">Started as analytics;</text>
+      <text x="826" y="42" font-size="12" fill="#6B7280">agentic primitives surface-level</text>
+    </g>
+
+    <!-- Row 4: OpenRouter -->
+    <g transform="translate(0,238)">
+      <rect width="1120" height="58" rx="6" fill="white" stroke="#E5E7EB"/>
+      <text x="16"  y="24" font-size="14" font-weight="700" fill="#0a0a0a">OpenRouter</text>
+      <text x="196" y="24" font-size="13" fill="#374151">Closed</text>
+      <text x="316" y="24" font-size="13" fill="#374151">No</text>
+      <text x="436" y="24" font-size="12" fill="#374151">290+ models,</text>
+      <text x="436" y="42" font-size="12" fill="#374151">passthrough pricing, one URL</text>
+      <text x="826" y="24" font-size="12" fill="#6B7280">Hosted only — they bill you,</text>
+      <text x="826" y="42" font-size="12" fill="#6B7280">not the provider</text>
+    </g>
+
+    <!-- Row 5: Vercel AI Gateway -->
+    <g transform="translate(0,302)">
+      <rect width="1120" height="58" rx="6" fill="white" stroke="#E5E7EB"/>
+      <text x="16"  y="24" font-size="14" font-weight="700" fill="#0a0a0a">Vercel AI Gateway</text>
+      <text x="196" y="24" font-size="13" fill="#374151">Node / Edge</text>
+      <text x="316" y="24" font-size="13" fill="#374151">No</text>
+      <text x="436" y="24" font-size="12" fill="#374151">Model fallbacks, Fluid-compute,</text>
+      <text x="436" y="42" font-size="12" fill="#374151">deep Next.js integration</text>
+      <text x="826" y="24" font-size="12" fill="#6B7280">Hosted; coupled to</text>
+      <text x="826" y="42" font-size="12" fill="#6B7280">Vercel platform</text>
+    </g>
+
+    <!-- Row 6: Bifrost -->
+    <g transform="translate(0,366)">
+      <rect width="1120" height="58" rx="6" fill="white" stroke="#E5E7EB"/>
+      <text x="16"  y="24" font-size="14" font-weight="700" fill="#0a0a0a">Bifrost (Maxim AI)</text>
+      <text x="196" y="24" font-size="13" fill="#374151">Go</text>
+      <text x="316" y="24" font-size="13" fill="#374151">Apache 2.0</text>
+      <text x="436" y="24" font-size="12" fill="#374151">11 µs overhead at 5k RPS,</text>
+      <text x="436" y="42" font-size="12" fill="#374151">1000+ models, governance + SSO</text>
+      <text x="826" y="24" font-size="12" fill="#6B7280">OpenAI-shaped wire format;</text>
+      <text x="826" y="42" font-size="12" fill="#6B7280">agents on top, not native</text>
+    </g>
+
+    <!-- Row 7: Opper AI -->
+    <g transform="translate(0,430)">
+      <rect width="1120" height="58" rx="6" fill="white" stroke="#E5E7EB"/>
+      <text x="16"  y="24" font-size="14" font-weight="700" fill="#0a0a0a">Opper AI</text>
+      <text x="196" y="24" font-size="13" fill="#374151">Managed</text>
+      <text x="316" y="24" font-size="13" fill="#374151">No</text>
+      <text x="436" y="24" font-size="12" fill="#374151">EU sovereignty, 300+ models,</text>
+      <text x="436" y="42" font-size="12" fill="#374151">LLM-as-a-judge scoring</text>
+      <text x="826" y="24" font-size="12" fill="#6B7280">Managed control plane,</text>
+      <text x="826" y="42" font-size="12" fill="#6B7280">not self-hostable</text>
+    </g>
+
+    <!-- Row 8: Aura (highlighted) -->
+    <g transform="translate(0,494)">
+      <rect width="1120" height="58" rx="6" fill="#7C3AED"/>
+      <text x="16"  y="26" font-size="14" font-weight="700" fill="white">Aura</text>
+      <text x="58"  y="26" font-size="11" font-weight="700" fill="#FDE68A">★</text>
+      <text x="196" y="26" font-size="13" fill="white">Rust</text>
+      <text x="316" y="26" font-size="13" fill="white">MIT</text>
+      <text x="436" y="24" font-size="12" fill="white">Agentic-native, Open Responses</text>
+      <text x="436" y="42" font-size="12" fill="white">API spec, multi-tenant by design</text>
+      <text x="826" y="24" font-size="12" fill="#EDE9FE">Earlier-stage;</text>
+      <text x="826" y="42" font-size="12" fill="#EDE9FE">7 providers as of v0.9</text>
+    </g>
+  </g>
+
+  <!-- Footnote -->
+  <text x="40" y="730" font-size="11" fill="#9CA3AF">
+    Sources: TrueFoundry, Helicone, OpenRouter docs (LiteLLM/Portkey/Helicone); Maxim AI blog (Bifrost); Opper AI blog. Compiled May 2026.
+  </text>
+</svg>

--- a/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/models.svg
+++ b/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/models.svg
@@ -1,0 +1,104 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 760" font-family="Inter, system-ui, sans-serif">
+  <rect width="1200" height="760" fill="#f9fafb"/>
+
+  <text x="40" y="44" font-size="13" font-weight="700" fill="#7C3AED" letter-spacing="2">MODEL FAMILIES SUPPORTED IN v0.9</text>
+  <text x="40" y="70" font-size="20" font-weight="700" fill="#0a0a0a">Resolve by family or by pinned version — Aura's registry handles both</text>
+  <text x="40" y="92" font-size="13" fill="#6B7280">7 providers. Anthropic and Gemini have full streaming + tool calls; the others add via the same Provider trait in one file.</text>
+
+  <!-- Card style: 360w x 200h. 3 cols × 3 rows -->
+  <!-- Row 1: OpenAI · Anthropic · Google -->
+  <g transform="translate(40,120)">
+    <rect width="360" height="200" rx="14" fill="white" stroke="#E5E7EB"/>
+    <text x="20" y="34" font-size="18" font-weight="700" fill="#0a0a0a">OpenAI</text>
+    <g transform="translate(20,46)">
+      <rect width="138" height="22" rx="11" fill="#7C3AED"/>
+      <text x="69" y="15" text-anchor="middle" font-size="11" font-weight="700" fill="white">STREAMING + TOOLS</text>
+    </g>
+    <text x="20" y="98"  font-size="12" fill="#374151">• GPT-5 family</text>
+    <text x="20" y="118" font-size="12" fill="#374151">• GPT-4o family</text>
+    <text x="20" y="138" font-size="12" fill="#374151">• o-series (o1, o3-mini)</text>
+    <text x="20" y="158" font-size="12" fill="#374151">• GPT-4 / 4-turbo / 3.5</text>
+    <text x="20" y="186" font-size="11" fill="#6B7280" font-style="italic">Aliases or pinned versions</text>
+  </g>
+
+  <g transform="translate(420,120)">
+    <rect width="360" height="200" rx="14" fill="white" stroke="#E5E7EB"/>
+    <text x="20" y="34" font-size="18" font-weight="700" fill="#0a0a0a">Anthropic</text>
+    <g transform="translate(20,46)">
+      <rect width="138" height="22" rx="11" fill="#7C3AED"/>
+      <text x="69" y="15" text-anchor="middle" font-size="11" font-weight="700" fill="white">STREAMING + TOOLS</text>
+    </g>
+    <text x="20" y="98"  font-size="12" fill="#374151">• Claude 4.5 (Opus, Sonnet)</text>
+    <text x="20" y="118" font-size="12" fill="#374151">• Claude 3.7 Sonnet</text>
+    <text x="20" y="138" font-size="12" fill="#374151">• Claude 3.5 (Sonnet, Haiku)</text>
+    <text x="20" y="158" font-size="12" fill="#374151">• Claude 3 (Opus, Sonnet, Haiku)</text>
+    <text x="20" y="186" font-size="11" fill="#6B7280" font-style="italic">claude-sonnet-4-5 → latest dated build</text>
+  </g>
+
+  <g transform="translate(800,120)">
+    <rect width="360" height="200" rx="14" fill="white" stroke="#E5E7EB"/>
+    <text x="20" y="34" font-size="18" font-weight="700" fill="#0a0a0a">Google Gemini</text>
+    <g transform="translate(20,46)">
+      <rect width="138" height="22" rx="11" fill="#7C3AED"/>
+      <text x="69" y="15" text-anchor="middle" font-size="11" font-weight="700" fill="white">STREAMING + TOOLS</text>
+    </g>
+    <text x="20" y="98"  font-size="12" fill="#374151">• Gemini 3 (Pro, Flash)</text>
+    <text x="20" y="118" font-size="12" fill="#374151">• Gemini 2.5 (Pro, Flash)</text>
+    <text x="20" y="138" font-size="12" fill="#374151">• Gemini 2.0 family</text>
+    <text x="20" y="158" font-size="12" fill="#374151">• Gemini 1.5 family</text>
+    <text x="20" y="186" font-size="11" fill="#6B7280" font-style="italic">Function calling on 2.0+</text>
+  </g>
+
+  <!-- Row 2: Mistral · Ollama · Bedrock -->
+  <g transform="translate(40,340)">
+    <rect width="360" height="200" rx="14" fill="white" stroke="#E5E7EB"/>
+    <text x="20" y="34" font-size="18" font-weight="700" fill="#0a0a0a">Mistral</text>
+    <text x="20" y="98"  font-size="12" fill="#374151">• Mistral Large 2</text>
+    <text x="20" y="118" font-size="12" fill="#374151">• Mistral Medium / Small</text>
+    <text x="20" y="138" font-size="12" fill="#374151">• Codestral</text>
+    <text x="20" y="186" font-size="11" fill="#6B7280" font-style="italic">OpenAI-compatible endpoint</text>
+  </g>
+
+  <g transform="translate(420,340)">
+    <rect width="360" height="200" rx="14" fill="white" stroke="#E5E7EB"/>
+    <text x="20" y="34" font-size="18" font-weight="700" fill="#0a0a0a">Ollama</text>
+    <text x="20" y="98"  font-size="12" fill="#374151">• Llama family (local)</text>
+    <text x="20" y="118" font-size="12" fill="#374151">• Mistral / Mixtral (local)</text>
+    <text x="20" y="138" font-size="12" fill="#374151">• Any Ollama-served model</text>
+    <text x="20" y="186" font-size="11" fill="#6B7280" font-style="italic">Bring your own local runtime</text>
+  </g>
+
+  <g transform="translate(800,340)">
+    <rect width="360" height="200" rx="14" fill="white" stroke="#E5E7EB"/>
+    <text x="20" y="34" font-size="18" font-weight="700" fill="#0a0a0a">AWS Bedrock</text>
+    <text x="20" y="98"  font-size="12" fill="#374151">• Claude via Bedrock</text>
+    <text x="20" y="118" font-size="12" fill="#374151">• Llama via Bedrock</text>
+    <text x="20" y="138" font-size="12" fill="#374151">• Titan models</text>
+    <text x="20" y="186" font-size="11" fill="#6B7280" font-style="italic">AWS SigV4 auth, region-pinned</text>
+  </g>
+
+  <!-- Row 3: HuggingFace + caption -->
+  <g transform="translate(40,560)">
+    <rect width="360" height="160" rx="14" fill="white" stroke="#E5E7EB"/>
+    <text x="20" y="34" font-size="18" font-weight="700" fill="#0a0a0a">HuggingFace</text>
+    <text x="20" y="74"  font-size="12" fill="#374151">• Any TGI endpoint</text>
+    <text x="20" y="94"  font-size="12" fill="#374151">• Inference Endpoints</text>
+    <text x="20" y="114" font-size="12" fill="#374151">• Public Inference API</text>
+    <text x="20" y="146" font-size="11" fill="#6B7280" font-style="italic">Pass your endpoint URL via config</text>
+  </g>
+
+  <g transform="translate(420,560)">
+    <rect width="740" height="160" rx="14" fill="#EDE9FE"/>
+    <text x="24" y="40" font-size="13" font-weight="700" fill="#7C3AED" letter-spacing="1.5">ADDING A PROVIDER</text>
+    <text x="24" y="74" font-size="15" fill="#0a0a0a">Implement the </text>
+    <text x="124" y="74" font-size="15" font-family="JetBrains Mono, monospace" font-weight="700" fill="#7C3AED">Provider</text>
+    <text x="200" y="74" font-size="15" fill="#0a0a0a"> trait in one file.</text>
+    <text x="24" y="98" font-size="13" fill="#374151">Defines </text>
+    <text x="78" y="98" font-size="13" font-family="JetBrains Mono, monospace" fill="#0a0a0a">complete()</text>
+    <text x="158" y="98" font-size="13" fill="#374151"> + </text>
+    <text x="182" y="98" font-size="13" font-family="JetBrains Mono, monospace" fill="#0a0a0a">complete_stream()</text>
+    <text x="320" y="98" font-size="13" fill="#374151">. Reports the models it serves;</text>
+    <text x="24" y="118" font-size="13" fill="#374151">registry maps model name → provider with zero routing config.</text>
+    <text x="24" y="146" font-size="11" fill="#6B7280" font-style="italic">See crates/aura-core/src/provider/ for the full list.</text>
+  </g>
+</svg>

--- a/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/what-worked.svg
+++ b/public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/what-worked.svg
@@ -1,0 +1,141 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 880" font-family="Inter, system-ui, sans-serif">
+  <rect width="1200" height="880" fill="#f9fafb"/>
+
+  <text x="40" y="44" font-size="13" font-weight="700" fill="#7C3AED" letter-spacing="2">VIBE ENGINEERING · RUST · CLAUDE CODE</text>
+  <text x="40" y="76" font-size="24" font-weight="700" fill="#0a0a0a" text-anchor="start">Rust, without being a Rust dev</text>
+
+  <!-- Two columns: worked (left, purple) + hurt (right, gray) -->
+  <!-- Column: 560w, starting x = 40 and 600 -->
+
+  <!-- WORKED -->
+  <g transform="translate(40,116)">
+    <rect width="560" height="700" rx="16" fill="#EDE9FE" opacity="0.4"/>
+    <rect width="560" height="700" rx="16" fill="none" stroke="#A78BFA"/>
+    <text x="24" y="42" font-size="13" font-weight="700" fill="#7C3AED" letter-spacing="2">WHAT WORKED</text>
+    <line x1="160" y1="38" x2="536" y2="38" stroke="#A78BFA" stroke-opacity="0.5"/>
+
+    <!-- Item 1 -->
+    <g transform="translate(24,72)">
+      <circle cx="12" cy="12" r="12" fill="#7C3AED"/>
+      <text x="12" y="17" text-anchor="middle" font-size="14" font-weight="700" fill="white">+</text>
+      <text x="36" y="14" font-size="14" font-weight="700" fill="#0a0a0a">Compiler errors are a teacher, not a wall.</text>
+      <text x="36" y="34" font-size="12" fill="#374151">With Claude Code reading the errors in context,</text>
+      <text x="36" y="50" font-size="12" fill="#374151">the borrow checker became a patient tutor.</text>
+    </g>
+
+    <!-- Item 2 -->
+    <g transform="translate(24,180)">
+      <circle cx="12" cy="12" r="12" fill="#7C3AED"/>
+      <text x="12" y="17" text-anchor="middle" font-size="14" font-weight="700" fill="white">+</text>
+      <text x="36" y="14" font-size="14" font-weight="700" fill="#0a0a0a">Types catch provider schema drift early.</text>
+      <text x="36" y="34" font-size="12" fill="#374151">LLM APIs drift. Strong types in</text>
+      <text x="222" y="34" font-size="12" font-family="JetBrains Mono, monospace" fill="#7C3AED">aura-types</text>
+      <text x="36" y="50" font-size="12" fill="#374151">caught two real schema changes before users.</text>
+    </g>
+
+    <!-- Item 3 -->
+    <g transform="translate(24,280)">
+      <circle cx="12" cy="12" r="12" fill="#7C3AED"/>
+      <text x="12" y="17" text-anchor="middle" font-size="14" font-weight="700" fill="white">+</text>
+      <text x="36" y="14" font-size="14" font-weight="700" fill="#0a0a0a">Single static binary, no runtime deps.</text>
+      <text x="36" y="34" font-size="12" font-family="JetBrains Mono, monospace" fill="#0a0a0a">cargo build --release</text>
+      <text x="208" y="34" font-size="12" fill="#374151">produces one file.</text>
+      <text x="36" y="50" font-size="12" fill="#374151">No virtualenv, no node_modules.</text>
+    </g>
+
+    <!-- Item 4 -->
+    <g transform="translate(24,380)">
+      <circle cx="12" cy="12" r="12" fill="#7C3AED"/>
+      <text x="12" y="17" text-anchor="middle" font-size="14" font-weight="700" fill="white">+</text>
+      <text x="36" y="14" font-size="14" font-weight="700" fill="#0a0a0a">Tokio handles SSE streaming cleanly.</text>
+      <text x="36" y="34" font-size="12" fill="#374151">Server-sent events are awkward in many runtimes.</text>
+      <text x="36" y="50" font-size="12" fill="#374151">In Tokio they're idiomatic.</text>
+    </g>
+
+    <!-- Item 5 -->
+    <g transform="translate(24,480)">
+      <circle cx="12" cy="12" r="12" fill="#7C3AED"/>
+      <text x="12" y="17" text-anchor="middle" font-size="14" font-weight="700" fill="white">+</text>
+      <text x="36" y="14" font-size="14" font-weight="700" fill="#0a0a0a">Claude Code is fluent in idiomatic Rust.</text>
+      <text x="36" y="34" font-size="12" fill="#374151">Not just compilable Rust.</text>
+      <text x="36" y="50" font-size="12" font-family="JetBrains Mono, monospace" fill="#0a0a0a">Arc&lt;T&gt; vs Arc&lt;Mutex&lt;T&gt;&gt;, tokio::spawn,</text>
+      <text x="36" y="68" font-size="12" fill="#374151">the right error-type idiom per crate.</text>
+    </g>
+
+    <!-- Item 6 -->
+    <g transform="translate(24,600)">
+      <circle cx="12" cy="12" r="12" fill="#7C3AED"/>
+      <text x="12" y="17" text-anchor="middle" font-size="14" font-weight="700" fill="white">+</text>
+      <text x="36" y="14" font-size="14" font-weight="700" fill="#0a0a0a">Refactors feel safe.</text>
+      <text x="36" y="34" font-size="12" fill="#374151">When the compiler signs off, you can ship it.</text>
+      <text x="36" y="50" font-size="12" fill="#374151">I'd never had that confidence in Python.</text>
+    </g>
+  </g>
+
+  <!-- HURT -->
+  <g transform="translate(600,116)">
+    <rect width="560" height="700" rx="16" fill="white"/>
+    <rect width="560" height="700" rx="16" fill="none" stroke="#E5E7EB"/>
+    <text x="24" y="42" font-size="13" font-weight="700" fill="#6B7280" letter-spacing="2">WHAT HURT</text>
+    <line x1="140" y1="38" x2="536" y2="38" stroke="#E5E7EB"/>
+
+    <g transform="translate(24,72)">
+      <circle cx="12" cy="12" r="12" fill="#9CA3AF"/>
+      <text x="12" y="17" text-anchor="middle" font-size="14" font-weight="700" fill="white">−</text>
+      <text x="36" y="14" font-size="14" font-weight="700" fill="#0a0a0a">Borrow checker + async = pain spikes.</text>
+      <text x="36" y="34" font-size="12" fill="#374151">Lifetimes meeting</text>
+      <text x="156" y="34" font-size="12" font-family="JetBrains Mono, monospace" fill="#0a0a0a">async</text>
+      <text x="194" y="34" font-size="12" fill="#374151">blocks is where Rust still hurts.</text>
+      <text x="36" y="50" font-size="12" fill="#374151">Claude Code helped, but we both bounced for hours.</text>
+    </g>
+
+    <g transform="translate(24,180)">
+      <circle cx="12" cy="12" r="12" fill="#9CA3AF"/>
+      <text x="12" y="17" text-anchor="middle" font-size="14" font-weight="700" fill="white">−</text>
+      <text x="36" y="14" font-size="14" font-weight="700" fill="#0a0a0a">Lifetimes took weeks to internalize.</text>
+      <text x="36" y="34" font-size="12" fill="#374151">The book teaches you the syntax.</text>
+      <text x="36" y="50" font-size="12" fill="#374151">Shipping production code teaches you what they mean.</text>
+    </g>
+
+    <g transform="translate(24,280)">
+      <circle cx="12" cy="12" r="12" fill="#9CA3AF"/>
+      <text x="12" y="17" text-anchor="middle" font-size="14" font-weight="700" fill="white">−</text>
+      <text x="36" y="14" font-size="14" font-weight="700" fill="#0a0a0a">The crate ecosystem is thinner for AI work.</text>
+      <text x="36" y="34" font-size="12" fill="#374151">Python has every LLM library a week after a paper drops.</text>
+      <text x="36" y="50" font-size="12" fill="#374151">Rust has some of them, eventually.</text>
+    </g>
+
+    <g transform="translate(24,380)">
+      <circle cx="12" cy="12" r="12" fill="#9CA3AF"/>
+      <text x="12" y="17" text-anchor="middle" font-size="14" font-weight="700" fill="white">−</text>
+      <text x="36" y="14" font-size="14" font-weight="700" fill="#0a0a0a">No </text>
+      <text x="68" y="14" font-size="14" font-family="JetBrains Mono, monospace" font-weight="700" fill="#0a0a0a">pip install</text>
+      <text x="156" y="14" font-size="14" font-weight="700" fill="#0a0a0a"> shortcuts.</text>
+      <text x="36" y="34" font-size="12" fill="#374151">Adding a Rust dep is a real decision —</text>
+      <text x="36" y="50" font-size="12" fill="#374151">features, version pins, compile time.</text>
+    </g>
+
+    <g transform="translate(24,480)">
+      <circle cx="12" cy="12" r="12" fill="#9CA3AF"/>
+      <text x="12" y="17" text-anchor="middle" font-size="14" font-weight="700" fill="white">−</text>
+      <text x="36" y="14" font-size="14" font-weight="700" fill="#0a0a0a">Compile times break flow state.</text>
+      <text x="36" y="34" font-size="12" fill="#374151">A cold incremental build on this workspace</text>
+      <text x="36" y="50" font-size="12" fill="#374151">hits 30+ seconds. You learn to batch.</text>
+    </g>
+
+    <g transform="translate(24,600)">
+      <circle cx="12" cy="12" r="12" fill="#9CA3AF"/>
+      <text x="12" y="17" text-anchor="middle" font-size="14" font-weight="700" fill="white">−</text>
+      <text x="36" y="14" font-size="14" font-weight="700" fill="#0a0a0a">Debugging async traits is a trip.</text>
+      <text x="36" y="34" font-size="12" fill="#374151">Errors from</text>
+      <text x="116" y="34" font-size="12" font-family="JetBrains Mono, monospace" fill="#0a0a0a">async_trait</text>
+      <text x="200" y="34" font-size="12" fill="#374151">macro expansions can be</text>
+      <text x="36" y="50" font-size="12" fill="#374151">40 lines of generics referencing types you didn't write.</text>
+    </g>
+  </g>
+
+  <!-- Punchline -->
+  <text x="600" y="852" text-anchor="middle" font-size="16" font-style="italic" fill="#7C3AED" font-weight="700">
+    Claude Code didn't replace Rust knowledge. It made Rust knowledge reachable.
+  </text>
+</svg>

--- a/scripts/convert-to-medium.js
+++ b/scripts/convert-to-medium.js
@@ -12,15 +12,18 @@ const __dirname = path.dirname(__filename);
  * Usage: node scripts/convert-to-medium.js <blog-post-slug>
  */
 
-function convertMDXToMedium(filePath) {
+const MEDIUM_TAG_LIMIT = 5;
+const SITE_BASE = 'https://umai-tech.com';
+
+function convertMDXToMedium(filePath, slug) {
   try {
     const content = fs.readFileSync(filePath, 'utf-8');
-    
+
     // Extract frontmatter
     const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n/);
     const frontmatter = frontmatterMatch ? frontmatterMatch[1] : '';
     const body = content.replace(/^---\n[\s\S]*?\n---\n/, '');
-    
+
     // Parse frontmatter
     const metadata = {};
     frontmatter.split('\n').forEach(line => {
@@ -30,156 +33,499 @@ function convertMDXToMedium(filePath) {
         metadata[key.trim()] = value;
       }
     });
-    
+
     // Convert body content
     let mediumContent = body;
-    
+
     // Remove import statements
     mediumContent = mediumContent.replace(/^import .+$/gm, '');
-    
+
     // Convert custom components to Medium-compatible format
-    mediumContent = convertComponents(mediumContent);
-    
+    mediumContent = convertComponents(mediumContent, slug);
+
     // Clean up extra whitespace
     mediumContent = mediumContent.replace(/\n{3,}/g, '\n\n');
-    
+
     return {
       title: metadata.title || 'Untitled',
       subtitle: metadata.description || '',
       content: mediumContent.trim(),
       tags: metadata.tags ? JSON.parse(metadata.tags) : [],
-      author: metadata.author || 'Marcus Elwin'
+      author: metadata.author || 'Marcus Elwin',
     };
-    
   } catch (error) {
     console.error('Error converting MDX:', error);
     return null;
   }
 }
 
-function convertComponents(content) {
+// Build a public URL to a Medium asset (SVG, etc.) for a given post slug.
+function mediumAsset(slug, filename) {
+  return `${SITE_BASE}/images/blog/${slug}/medium/${filename}`;
+}
+
+// Strip MDX/HTML-ish tags inside short text payloads.
+// Keeps Markdown by translating <strong>/<code>/<em> to their MD equivalents
+// before stripping any remaining tags.
+function stripInlineTags(text) {
+  if (!text) return '';
+  return text
+    .replace(/<strong>([\s\S]*?)<\/strong>/g, '**$1**')
+    .replace(/<em>([\s\S]*?)<\/em>/g, '*$1*')
+    .replace(/<code>([\s\S]*?)<\/code>/g, '`$1`')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .trim();
+}
+
+// Very forgiving extractor for `prop="value"` and `prop={...}` literals.
+// Returns the matched value (string for quoted, raw for braced) or null.
+function extractProp(block, prop) {
+  const quoted = block.match(new RegExp(`${prop}="([^"]*)"`));
+  if (quoted) return quoted[1];
+  // Match `prop={...}` honoring balanced braces. Greedy enough for our props.
+  const braced = block.match(new RegExp(`${prop}=\\{([\\s\\S]*?)\\}(?=\\s+\\w+=|\\s*/?>)`));
+  if (braced) return braced[1];
+  return null;
+}
+
+// Extract a balanced `[ ... ]` JS array literal that follows `prop=`.
+// Returns the inner text between the outer [ and ], or null.
+function extractArrayProp(block, prop) {
+  const idx = block.indexOf(`${prop}={`);
+  if (idx === -1) return null;
+  // Walk from the `{` to find the matching `}` while tracking [ ] and string state.
+  let i = block.indexOf('{', idx);
+  if (i === -1) return null;
+  // Inside the `{ ... }` we expect a `[ ... ]`.
+  const open = block.indexOf('[', i);
+  if (open === -1) return null;
+  let depth = 0;
+  let inStr = null;
+  for (let p = open; p < block.length; p++) {
+    const ch = block[p];
+    if (inStr) {
+      if (ch === '\\') { p++; continue; }
+      if (ch === inStr) inStr = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') { inStr = ch; continue; }
+    if (ch === '[') depth++;
+    else if (ch === ']') {
+      depth--;
+      if (depth === 0) {
+        return block.slice(open + 1, p);
+      }
+    }
+  }
+  return null;
+}
+
+// Split an array of object literals (top-level `{...}, {...}`) into raw object
+// chunks. Ignores commas inside nested braces / brackets / strings.
+function splitObjectArray(inner) {
+  const out = [];
+  let depth = 0;
+  let inStr = null;
+  let start = -1;
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (inStr) {
+      if (ch === '\\') { i++; continue; }
+      if (ch === inStr) inStr = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') { inStr = ch; continue; }
+    if (ch === '{' || ch === '[') {
+      if (ch === '{' && depth === 0) start = i;
+      depth++;
+    } else if (ch === '}' || ch === ']') {
+      depth--;
+      if (depth === 0 && ch === '}' && start !== -1) {
+        out.push(inner.slice(start, i + 1));
+        start = -1;
+      }
+    }
+  }
+  return out;
+}
+
+// Extract a `key: "value"` or `key: 'value'` or `key: \`value\`` from an object literal.
+function objField(objText, key) {
+  // Try double, single, template, in that order.
+  const patterns = [
+    new RegExp(`${key}\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)"`),
+    new RegExp(`${key}\\s*:\\s*'((?:[^'\\\\]|\\\\.)*)'`),
+    new RegExp(`${key}\\s*:\\s*\`((?:[^\`\\\\]|\\\\.)*)\``),
+  ];
+  for (const p of patterns) {
+    const m = objText.match(p);
+    if (m) {
+      // Unescape standard escape sequences used in the source MDX.
+      return m[1]
+        .replace(/\\n/g, '\n')
+        .replace(/\\t/g, '\t')
+        .replace(/\\"/g, '"')
+        .replace(/\\'/g, "'")
+        .replace(/\\`/g, '`')
+        .replace(/\\\$/g, '$')
+        .replace(/\\\\/g, '\\');
+    }
+  }
+  return '';
+}
+
+// Extract an array-of-strings field: `key: ["a", "b"]`
+function objArrayField(objText, key) {
+  const m = objText.match(new RegExp(`${key}\\s*:\\s*\\[([\\s\\S]*?)\\]`));
+  if (!m) return [];
+  const inner = m[1];
+  const out = [];
+  const re = /"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'/g;
+  let mm;
+  while ((mm = re.exec(inner)) !== null) {
+    out.push((mm[1] ?? mm[2]).replace(/\\"/g, '"').replace(/\\'/g, "'"));
+  }
+  return out;
+}
+
+function convertComponents(content, slug) {
   let converted = content;
-  
-  // Convert Callout components to blockquotes
+
+  // ---- Callout → blockquote with bold title ---------------------------------
   converted = converted.replace(
     /<Callout[^>]*title="([^"]*)"[^>]*>([\s\S]*?)<\/Callout>/g,
     (_, title, body) => {
-      const cleanBody = body.replace(/<[^>]*>/g, '').trim();
-      return `> **${title}**\n> \n> ${cleanBody}`;
+      const cleanBody = stripInlineTags(body);
+      return `> **${title}**\n> \n> ${cleanBody.replace(/\n/g, '\n> ')}`;
     }
   );
-  
-  // Convert Citation components to styled quotes
+
+  // ---- Citation → quote with attribution ------------------------------------
   converted = converted.replace(
     /<Citation[^>]*author="([^"]*)"[^>]*source="([^"]*)"[^>]*>([\s\S]*?)<\/Citation>/g,
     (_, author, source, quote) => {
-      const cleanQuote = quote.replace(/<[^>]*>/g, '').trim();
+      const cleanQuote = stripInlineTags(quote);
       return `> *"${cleanQuote}"*\n> \n> — ${author}, ${source}`;
     }
   );
-  
-  // Convert ResearchInsights to formatted sections
+
+  // ---- ResearchInsights (legacy) -------------------------------------------
   converted = converted.replace(
     /<ResearchInsights[^>]*title="([^"]*)"[^>]*>([\s\S]*?)<\/ResearchInsights>/g,
-    (_, title, content) => {
-      // Format as Medium-compatible content  
+    (_, title, body) => {
       let result = `## ${title}\n\n`;
-      
-      // Look for Walmart Strategy
-      if (content.includes('Walmart Strategy')) {
+      if (body.includes('Walmart Strategy')) {
         result += `**Walmart Strategy**: 50% revenue target through AI agents (5 years)\n`;
         result += `*Incumbent validation - retail giants are all-in*\n\n`;
       }
-      
-      // Look for B2B Negotiations
-      if (content.includes('Pactum AI')) {
+      if (body.includes('Pactum AI')) {
         result += `**B2B Negotiations (Pactum AI)**: 40% cost savings in autonomous negotiations\n`;
         result += `*Proven ROI - agents outperform humans*\n\n`;
       }
-      
-      // Look for Infrastructure/Technical
-      if (content.includes('Technical convergence') || content.includes('Infrastructure')) {
+      if (body.includes('Technical convergence') || body.includes('Infrastructure')) {
         result += `**Infrastructure Ready**: Technical convergence enables scale\n`;
         result += `*Payment rails + APIs + composable checkout ready*\n\n`;
       }
-      
       return result;
     }
   );
-  
-  // Remove other custom components (replace with fallback text)
+
+  // ---- ZoomableFrame → transparent wrapper, keep inner content --------------
+  converted = converted.replace(
+    /<ZoomableFrame[^>]*>([\s\S]*?)<\/ZoomableFrame>/g,
+    (_, inner) => inner.trim()
+  );
+
+  // ---- CodeTerminal (multi-tab via examples=[...]) --------------------------
+  // Run first so it captures examples-mode blocks before the single-mode rule.
+  converted = converted.replace(
+    /<CodeTerminal\b([\s\S]*?)\/>/g,
+    (match) => renderCodeTerminal(match)
+  );
+
+  // ---- GatewayLandscapeMatrix ----------------------------------------------
+  converted = converted.replace(
+    /<GatewayLandscapeMatrix\b([\s\S]*?)\/>/g,
+    (match) => renderGatewayMatrix(match, slug)
+  );
+
+  // ---- CrateWorkspace -------------------------------------------------------
+  converted = converted.replace(
+    /<CrateWorkspace\b([\s\S]*?)\/>/g,
+    (match) => renderCrateWorkspace(match, slug)
+  );
+
+  // ---- AuraArchitectureDiagram (self-closing or empty) ----------------------
+  converted = converted.replace(
+    /<AuraArchitectureDiagram\s*\/>/g,
+    () => `![Aura architecture diagram](${mediumAsset(slug, 'architecture.svg')})`
+  );
+
+  // ---- SupportedModelsGrid --------------------------------------------------
+  converted = converted.replace(
+    /<SupportedModelsGrid\b([\s\S]*?)\/>/g,
+    (match) => renderModelsGrid(match, slug)
+  );
+
+  // ---- LoadTestChart --------------------------------------------------------
+  converted = converted.replace(
+    /<LoadTestChart\s*\/>/g,
+    () =>
+      `![Gateway load-test results](${mediumAsset(slug, 'loadtest.svg')})\n\n` +
+      `*Numbers above are directional placeholders pending the live benchmark run — see [the original post](${SITE_BASE}/blog/building-aura-an-agentic-llm-gateway-in-rust) for the interactive chart.*`
+  );
+
+  // ---- WhatWorkedWhatHurt ---------------------------------------------------
+  converted = converted.replace(
+    /<WhatWorkedWhatHurt\b([\s\S]*?)\/>/g,
+    (match) => renderWhatWorkedWhatHurt(match, slug)
+  );
+
+  // ---- LessonsGrid ----------------------------------------------------------
+  converted = converted.replace(
+    /<LessonsGrid\b([\s\S]*?)\/>/g,
+    (match) => renderLessonsGrid(match, slug)
+  );
+
+  // ---- Catch-all for any remaining custom components ------------------------
   converted = converted.replace(/<[A-Z][^>]*\/>/g, '[Interactive Component - See Original Post]');
-  converted = converted.replace(/<[A-Z][^>]*>[\s\S]*?<\/[A-Z][^>]*>/g, '[Interactive Component - See Original Post]');
-  
-  // Convert special formatting
-  converted = converted.replace(/\*\*([^*]+)\*\*/g, '**$1**'); // Keep bold
-  converted = converted.replace(/\*([^*]+)\*/g, '*$1*'); // Keep italic
-  
+  converted = converted.replace(/<[A-Z][A-Za-z0-9]*\b[\s\S]*?<\/[A-Z][A-Za-z0-9]*>/g, '[Interactive Component - See Original Post]');
+
   return converted;
 }
 
+// ---------- Renderers --------------------------------------------------------
+
+function renderCodeTerminal(block) {
+  // Single-block mode: code="..." lang="..." label?
+  // Multi-tab mode: examples={[ { label, lang, code }, ... ]}
+  const arrInner = extractArrayProp(block, 'examples');
+
+  if (arrInner) {
+    const objs = splitObjectArray(arrInner);
+    const parts = objs.map((o) => {
+      const label = objField(o, 'label');
+      const lang = objField(o, 'lang') || 'text';
+      const code = objField(o, 'code');
+      const header = label ? `**${label}**\n\n` : '';
+      return `${header}\`\`\`${lang}\n${code}\n\`\`\``;
+    });
+    return parts.join('\n\n');
+  }
+
+  const code = extractProp(block, 'code');
+  const lang = extractProp(block, 'lang') || 'text';
+  const label = extractProp(block, 'label');
+  if (code === null) return '';
+  // `extractProp` may return the inner of a `{...}` for template strings — strip
+  // surrounding backticks if present.
+  const cleanCode = code.replace(/^`([\s\S]*)`$/, '$1');
+  const header = label ? `**${label}**\n\n` : '';
+  return `${header}\`\`\`${lang}\n${cleanCode}\n\`\`\``;
+}
+
+function renderGatewayMatrix(block, slug) {
+  const inner = extractArrayProp(block, 'gateways');
+  const img = `![Gateway landscape matrix](${mediumAsset(slug, 'matrix.svg')})`;
+  if (!inner) return img;
+
+  const rows = splitObjectArray(inner).map((o) => ({
+    name: objField(o, 'name'),
+    language: objField(o, 'language'),
+    openSource: objField(o, 'openSource'),
+    strength: objField(o, 'strength'),
+    gap: objField(o, 'gap'),
+  }));
+
+  let md = `${img}\n\n`;
+  md += `| Gateway | Language | Open Source | Strength | Gap |\n`;
+  md += `|---|---|---|---|---|\n`;
+  for (const r of rows) {
+    md += `| **${r.name}** | ${r.language} | ${r.openSource} | ${r.strength} | ${r.gap} |\n`;
+  }
+  return md;
+}
+
+function renderCrateWorkspace(block, slug) {
+  const inner = extractArrayProp(block, 'crates');
+  const img = `![Aura Cargo workspace](${mediumAsset(slug, 'crates.svg')})`;
+  if (!inner) return img;
+
+  const crates = splitObjectArray(inner).map((o) => ({
+    name: objField(o, 'name'),
+    role: objField(o, 'role'),
+    detail: objField(o, 'detail'),
+    modules: objArrayField(o, 'modules'),
+    deps: objArrayField(o, 'deps'),
+    exposes: objArrayField(o, 'exposes'),
+    source: objField(o, 'source'),
+  }));
+
+  let md = `${img}\n\n`;
+  for (const c of crates) {
+    md += `### \`${c.name}\` — ${c.role}\n\n`;
+    if (c.detail) md += `${c.detail}\n\n`;
+    if (c.modules.length) md += `**Modules:** ${c.modules.map((m) => `\`${m}\``).join(', ')}\n\n`;
+    if (c.deps.length) md += `**Dependencies:** ${c.deps.map((d) => `\`${d}\``).join(', ')}\n\n`;
+    if (c.exposes.length) {
+      md += `**Exposes:**\n\n`;
+      for (const e of c.exposes) md += `- ${e}\n`;
+      md += `\n`;
+    }
+    if (c.source) md += `*Source:* \`${c.source}\`\n\n`;
+  }
+  return md;
+}
+
+function renderModelsGrid(block, slug) {
+  const inner = extractArrayProp(block, 'providers');
+  const img = `![Supported model families](${mediumAsset(slug, 'models.svg')})`;
+  if (!inner) return img;
+
+  const rows = splitObjectArray(inner).map((o) => ({
+    provider: objField(o, 'provider'),
+    badge: objField(o, 'badge'),
+    families: objArrayField(o, 'families'),
+    notes: objField(o, 'notes'),
+  }));
+
+  let md = `${img}\n\n`;
+  md += `| Provider | Capabilities | Families | Notes |\n`;
+  md += `|---|---|---|---|\n`;
+  for (const r of rows) {
+    md += `| **${r.provider}** | ${r.badge || '—'} | ${r.families.join(', ')} | ${r.notes} |\n`;
+  }
+  return md;
+}
+
+function renderWhatWorkedWhatHurt(block, slug) {
+  const worked = splitTopLevelStrings(extractArrayProp(block, 'worked') || '');
+  const hurt = splitTopLevelStrings(extractArrayProp(block, 'hurt') || '');
+  const title = extractProp(block, 'title');
+  const punchline = extractProp(block, 'punchline');
+  const img = `![What worked vs. what hurt](${mediumAsset(slug, 'what-worked.svg')})`;
+
+  let md = `${img}\n\n`;
+  if (title) md += `### ${title}\n\n`;
+  md += `**What worked**\n\n`;
+  for (const w of worked) md += `- ${stripInlineTags(w)}\n`;
+  md += `\n**What hurt**\n\n`;
+  for (const h of hurt) md += `- ${stripInlineTags(h)}\n`;
+  if (punchline) md += `\n*${stripInlineTags(punchline)}*\n`;
+  return md;
+}
+
+function renderLessonsGrid(block, slug) {
+  const inner = extractArrayProp(block, 'lessons');
+  const title = extractProp(block, 'title');
+  const img = `![Lessons learned](${mediumAsset(slug, 'lessons.svg')})`;
+
+  let md = `${img}\n\n`;
+  if (title) md += `### ${title}\n\n`;
+  if (!inner) return md;
+
+  const lessons = splitObjectArray(inner).map((o) => ({
+    title: objField(o, 'title'),
+    body: objField(o, 'body'),
+  }));
+
+  lessons.forEach((l, i) => {
+    md += `${i + 1}. **${l.title}** — ${l.body}\n`;
+  });
+  return md;
+}
+
+// Split an array of string literals (e.g. ["a", "b", `c`]) into raw entries
+// preserving their unescaped contents. Used by WhatWorkedWhatHurt.
+function splitTopLevelStrings(inner) {
+  const out = [];
+  const re = /"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|`((?:[^`\\]|\\.)*)`/g;
+  let m;
+  while ((m = re.exec(inner)) !== null) {
+    const raw = m[1] ?? m[2] ?? m[3];
+    out.push(
+      raw
+        .replace(/\\n/g, '\n')
+        .replace(/\\t/g, '\t')
+        .replace(/\\"/g, '"')
+        .replace(/\\'/g, "'")
+        .replace(/\\`/g, '`')
+        .replace(/\\\\/g, '\\')
+    );
+  }
+  return out;
+}
+
 async function generateImportUrl(_article) {
-  // Generate a GitHub Gist or use existing blog URL for Medium import
   console.log('\n📌 Medium Import Options:');
   console.log('1. Copy the converted content and paste directly into Medium');
   console.log('2. Import from your blog URL: https://umai-tech.com/blog/[slug]');
   console.log('3. Create a GitHub Gist and import from there');
-  
   return null;
 }
 
 // Main execution
 async function main() {
   const args = process.argv.slice(2);
-  
+
   if (args.length === 0) {
     console.log('Usage: node scripts/convert-to-medium.js <blog-post-slug>');
-    console.log('Example: node scripts/convert-to-medium.js agentic-commerce-the-dawn-of-a-new-ai-driven-era-for-ecommerce');
+    console.log('Example: node scripts/convert-to-medium.js building-aura-an-agentic-llm-gateway-in-rust');
     process.exit(1);
   }
-  
+
   const slug = args[0];
-  
   const blogPath = path.join(__dirname, '..', 'src', 'content', 'blog', `${slug}.mdx`);
-  
+
   if (!fs.existsSync(blogPath)) {
     console.error(`❌ Blog post not found: ${blogPath}`);
     process.exit(1);
   }
-  
+
   console.log(`🔄 Converting ${slug} to Medium format...`);
-  
-  const article = convertMDXToMedium(blogPath);
-  
+
+  const article = convertMDXToMedium(blogPath, slug);
   if (!article) {
     console.error('❌ Failed to convert article');
     process.exit(1);
   }
-  
-  // Save converted content to file
+
   const outputPath = path.join(__dirname, '..', 'dist', `${slug}-medium.md`);
   const outputDir = path.dirname(outputPath);
-  
   if (!fs.existsSync(outputDir)) {
     fs.mkdirSync(outputDir, { recursive: true });
   }
-  
+
+  const tags = (article.tags || []).slice(0, MEDIUM_TAG_LIMIT);
+
   const mediumOutput = `# ${article.title}
 
 ${article.subtitle ? `*${article.subtitle}*\n\n` : ''}${article.content}
 
 ---
 
-*Originally published at [umai-tech.com](https://umai-tech.com)*
+*Originally published at [umai-tech.com](${SITE_BASE}/blog/${slug})*
 
-Tags: ${article.tags.join(', ')}`;
-  
+Tags: ${tags.join(', ')}`;
+
   fs.writeFileSync(outputPath, mediumOutput);
   console.log(`✅ Converted content saved to: ${outputPath}`);
-  
-  // Show import options
+
+  // Surface which SVGs the post references so the user knows what to upload.
+  const referenced = [...mediumOutput.matchAll(/medium\/([\w-]+\.svg)/g)].map((m) => m[1]);
+  const unique = Array.from(new Set(referenced));
+  if (unique.length) {
+    console.log('\n🖼  SVG assets referenced (upload these to public/images/blog/' + slug + '/medium/):');
+    for (const f of unique) console.log('  - ' + f);
+  }
+
   await generateImportUrl(article);
-  
+
   console.log('\n✨ Next Steps:');
   console.log('1. Copy content from:', outputPath);
   console.log('2. Go to: https://medium.com/new-story');


### PR DESCRIPTION
## Summary

- Hand-author **8 standalone SVGs** for the Aura LLM Gateway post so it can be republished on Medium without losing the interactive visuals. SVGs live at `public/images/blog/building-aura-an-agentic-llm-gateway-in-rust/medium/`.
- Extend `scripts/convert-to-medium.js` with handlers for **9 more components** (`CodeTerminal`, `GatewayLandscapeMatrix`, `CrateWorkspace`, `AuraArchitectureDiagram`, `SupportedModelsGrid`, `LoadTestChart`, `WhatWorkedWhatHurt`, `LessonsGrid`, `ZoomableFrame`). Each degrades to Medium-friendly Markdown (tables, bulleted/numbered lists, fenced code) with an inline image reference to the matching SVG.
- Trim tags to Medium's 5-tag limit, decode HTML entities that are baked into MDX string literals.

## SVGs added

| File | Purpose |
|---|---|
| `architecture.svg` | 4-layer Clients → Gateway → Providers diagram |
| `loadtest.svg` | Gateway overhead bar chart, 5 scenarios × 6 gateways |
| `matrix.svg` | 8-gateway comparison table, Aura row highlighted |
| `crates.svg` | 4-crate Cargo workspace 2×2 grid |
| `models.svg` | 7 provider cards |
| `what-worked.svg` | Vibe-engineering Rust two-column comparison |
| `lessons.svg` | 6 numbered lesson cards |
| `aura-hero.svg` | 1200×630 social-card header |

All SVGs are XML-valid, light-mode only, between 3.5 KB and 10 KB, and use Inter + JetBrains Mono inline (no remote fonts). They reference the umai purple `#8B5CF6` as the brand color.

## Test plan

- [ ] Vercel preview deploy builds without errors
- [ ] Open each SVG via the preview URL and confirm it renders standalone (text legible, no broken paths)
- [ ] Run locally: `pnpm convert-to-medium building-aura-an-agentic-llm-gateway-in-rust` produces `dist/building-aura-an-agentic-llm-gateway-in-rust-medium.md`
- [ ] Verify the output: 0 `[Interactive Component]` placeholders, 7 SVG references, tag line trimmed to 5 tags, no stray `&lt;`/`&gt;` entities
- [ ] After merge + production deploy: paste the converted `.md` into https://medium.com/new-story as a draft and confirm Medium fetches all SVGs from `umai-tech.com`

## Notes

- The `dist/` output is gitignored — only the converter and SVG assets ship in this PR.
- The .md generated by the converter references SVG URLs at `https://umai-tech.com/images/blog/.../medium/*.svg`, so the SVGs need to be live in production before Medium import will work. Merge → wait for Vercel deploy → then paste into Medium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)