### PR TITLE
fix(mobile): improve responsiveness and viewport handling

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -34,21 +34,36 @@ const navItems = [
         <span class="text-xl font-light text-gray-900 dark:text-white">umai<span class="font-semibold text-umai-accent-darker">-tech</span></span>
       </a>
 
-      <!-- Navigation -->
-      <div class="hidden md:flex items-center space-x-8">
-        {navItems.map((item) => (
-          <a href={item.href} class="text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-umai-accent dark:hover:text-umai-accent transition-colors">
-            {item.name}
-          </a>
-        ))}
-      </div>
+      <!-- Right-side cluster -->
+      <div class="flex items-center gap-1 sm:gap-3">
+        <!-- Navigation -->
+        <div class="hidden md:flex items-center space-x-8">
+          {navItems.map((item) => (
+            <a href={item.href} class="text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-umai-accent dark:hover:text-umai-accent transition-colors">
+              {item.name}
+            </a>
+          ))}
+        </div>
 
-      <!-- Mobile menu button -->
-      <button id="mobile-menu-button" class="md:hidden p-2.5 -mr-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800" aria-label="Open mobile menu" aria-expanded="false">
-        <svg class="w-6 h-6 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-        </svg>
-      </button>
+        <!-- Theme toggle -->
+        <button type="button" class="theme-toggle p-2.5 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" aria-label="Toggle dark mode">
+          <!-- Moon (shown in light mode) -->
+          <svg class="w-5 h-5 block dark:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+          </svg>
+          <!-- Sun (shown in dark mode) -->
+          <svg class="w-5 h-5 hidden dark:block" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+          </svg>
+        </button>
+
+        <!-- Mobile menu button -->
+        <button id="mobile-menu-button" class="md:hidden p-2.5 -mr-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800" aria-label="Open mobile menu" aria-expanded="false">
+          <svg class="w-6 h-6 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+          </svg>
+        </button>
+      </div>
     </div>
   </nav>
   
@@ -115,6 +130,19 @@ const navItems = [
       <!-- Enhanced Footer with Grid Layout -->
       <div class="px-8 py-10">
         <div class="grid grid-cols-1 gap-6 text-center">
+          <!-- Theme toggle -->
+          <div class="flex justify-center">
+            <button type="button" class="theme-toggle inline-flex items-center gap-2 px-5 py-3 rounded-full border border-umai-accent/25 text-gray-700 dark:text-gray-200 hover:bg-umai-accent/10 transition-colors" aria-label="Toggle dark mode">
+              <svg class="w-5 h-5 block dark:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+              </svg>
+              <svg class="w-5 h-5 hidden dark:block" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+              </svg>
+              <span class="text-sm font-medium"><span class="hidden dark:inline">Light mode</span><span class="inline dark:hidden">Dark mode</span></span>
+            </button>
+          </div>
+
           <!-- Tagline Section -->
           <div class="space-y-2">
             <div class="text-base font-medium text-gray-600 dark:text-gray-300 tracking-wide">
@@ -139,6 +167,20 @@ const navItems = [
 </header>
 
 <script>
+  // Dark mode toggle (initial theme is applied pre-paint in Layout.astro)
+  function applyTheme(isDark: boolean) {
+    document.documentElement.classList.toggle('dark', isDark);
+    try {
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    } catch (e) {}
+  }
+
+  document.querySelectorAll('.theme-toggle').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      applyTheme(!document.documentElement.classList.contains('dark'));
+    });
+  });
+
   // Mobile menu functionality
   const mobileMenuButton = document.getElementById('mobile-menu-button');
   const mobileMenuClose = document.getElementById('mobile-menu-close');

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -44,7 +44,7 @@ const navItems = [
       </div>
 
       <!-- Mobile menu button -->
-      <button id="mobile-menu-button" class="md:hidden p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800" aria-label="Open mobile menu" aria-expanded="false">
+      <button id="mobile-menu-button" class="md:hidden p-2.5 -mr-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800" aria-label="Open mobile menu" aria-expanded="false">
         <svg class="w-6 h-6 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
         </svg>
@@ -145,8 +145,6 @@ const navItems = [
   const mobileMenu = document.getElementById('mobile-menu');
   
   function openMobileMenu() {
-    console.log('Opening mobile menu...');
-    
     if (mobileMenu) {
       // Show menu with new CSS approach
       mobileMenu.classList.add('show');
@@ -216,11 +214,20 @@ const navItems = [
   .mobile-menu-content {
     display: flex;
     flex-direction: column;
+    /* Fallback for older browsers, then dynamic viewport height so the
+       menu is not clipped behind mobile browser chrome (URL/address bar). */
     height: 100vh;
+    height: 100dvh;
     width: 100vw;
+    width: 100dvw;
     background: inherit;
     position: relative;
-    overflow: hidden;
+    /* Allow the menu to scroll on very short screens instead of clipping. */
+    overflow-x: hidden;
+    overflow-y: auto;
+    /* Respect notches / home indicators on modern phones. */
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
   }
   
   /* Subtle background pattern */

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,7 +1,7 @@
 ---
 ---
 
-<section class="relative min-h-[85vh] flex items-center justify-center px-4 sm:px-6 lg:px-8 bg-white dark:bg-umai-primary">
+<section class="relative min-h-[85vh] overflow-hidden flex items-center justify-center px-4 sm:px-6 lg:px-8 bg-white dark:bg-umai-primary">
   <!-- Subtle purple gradient overlay -->
   <div class="absolute inset-0 bg-gradient-to-br from-umai-accent/5 via-transparent to-umai-accent/5"></div>
   
@@ -26,7 +26,7 @@
       </div>
     </div>
 
-    <h1 class="text-6xl sm:text-7xl lg:text-8xl font-extralight text-center text-gray-900 dark:text-white mb-6">
+    <h1 class="text-5xl sm:text-7xl lg:text-8xl font-extralight text-center text-gray-900 dark:text-white mb-6">
       Umai<span class="font-normal text-umai-accent">Tech</span>
     </h1>
 

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -97,9 +97,18 @@ const tocHeadings = headings.filter(h => h.depth >= 2 && h.depth <= 4);
         toggleTOC();
       });
       
-      // Set initial state
-      (tocContent as HTMLElement).style.maxHeight = (tocContent as HTMLElement).scrollHeight + 'px';
-      (tocContent as HTMLElement).style.opacity = '1';
+      // Set initial state: collapsed on mobile (where the TOC stacks below
+      // the article), expanded on larger screens where it sits in the sidebar.
+      const startCollapsed = window.matchMedia('(max-width: 1023px)').matches;
+      if (startCollapsed) {
+        (tocContent as HTMLElement).style.maxHeight = '0';
+        (tocContent as HTMLElement).style.opacity = '0';
+        (tocChevron as HTMLElement).style.transform = 'rotate(-90deg)';
+        tocToggle.setAttribute('aria-expanded', 'false');
+      } else {
+        (tocContent as HTMLElement).style.maxHeight = (tocContent as HTMLElement).scrollHeight + 'px';
+        (tocContent as HTMLElement).style.opacity = '1';
+      }
     }
     
     // Smooth scrolling for TOC links

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -20,6 +20,19 @@ const { title, description = 'Umai Tech - AI, GenAI, ML Blog and Insights', noHe
     <meta charset="UTF-8" />
     <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- Apply theme before paint to avoid a flash of the wrong color scheme -->
+    <script is:inline>
+      (function () {
+        try {
+          var stored = localStorage.getItem('theme');
+          var isDark = stored
+            ? stored === 'dark'
+            : window.matchMedia('(prefers-color-scheme: dark)').matches;
+          document.documentElement.classList.toggle('dark', isDark);
+        } catch (e) {}
+      })();
+    </script>
     
     <!-- Favicon with cache busting -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2025" />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -21,7 +21,7 @@ import TeamSection from '../components/TeamSection.astro';
           <!-- Kanji Display -->
           <div class="text-center md:text-right">
             <div class="inline-block relative">
-              <div class="text-8xl sm:text-9xl font-japanese text-umai-accent mb-4 relative">
+              <div class="text-7xl sm:text-8xl lg:text-9xl font-japanese text-umai-accent mb-4 relative">
                 <span class="kanji-char" style="--delay: 0s">う</span><span class="kanji-char" style="--delay: 0.5s">ま</span><span class="kanji-char" style="--delay: 1s">い</span>
                 <div class="absolute -inset-4 bg-umai-accent/5 rounded-3xl blur-2xl -z-10"></div>
               </div>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -152,6 +152,19 @@ const { Content, headings } = await entry.render();
   </article>
 </Layout>
 
+<script>
+  // Wrap any wide tables rendered from Markdown in a horizontally
+  // scrollable container so they don't blow out the layout on mobile.
+  document.querySelectorAll('.blog-content table').forEach((table) => {
+    const parent = table.parentElement;
+    if (!parent || parent.classList.contains('table-scroll')) return;
+    const wrapper = document.createElement('div');
+    wrapper.className = 'table-scroll';
+    parent.insertBefore(wrapper, table);
+    wrapper.appendChild(table);
+  });
+</script>
+
 <style>
   .blog-content {
     /* Headings */
@@ -318,6 +331,17 @@ const { Content, headings } = await entry.render();
   /* Improve table responsive design */
   .blog-content :global(table) {
     @apply text-sm;
+  }
+
+  /* Wrapper added by the script below so wide tables scroll horizontally
+     on mobile instead of overflowing the page. */
+  .blog-content :global(.table-scroll) {
+    @apply block w-full overflow-x-auto my-6;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .blog-content :global(.table-scroll) > :global(table) {
+    @apply my-0;
   }
   
   /* Add reading flow improvements */

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -255,7 +255,7 @@ import Layout from '../layouts/Layout.astro';
   </section>
 
   <!-- Success/Error Messages -->
-  <div id="successMessage" class="fixed bottom-6 right-6 bg-green-500 text-white px-6 py-4 rounded-lg shadow-lg transform translate-x-full transition-transform duration-300 z-50">
+  <div id="successMessage" class="fixed bottom-4 left-4 right-4 sm:left-auto sm:bottom-6 sm:right-6 bg-green-500 text-white px-6 py-4 rounded-lg shadow-lg transform translate-x-full transition-transform duration-300 z-50">
     <div class="flex items-center">
       <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
@@ -264,7 +264,7 @@ import Layout from '../layouts/Layout.astro';
     </div>
   </div>
 
-  <div id="errorMessage" class="fixed bottom-6 right-6 bg-red-500 text-white px-6 py-4 rounded-lg shadow-lg transform translate-x-full transition-transform duration-300 z-50">
+  <div id="errorMessage" class="fixed bottom-4 left-4 right-4 sm:left-auto sm:bottom-6 sm:right-6 bg-red-500 text-white px-6 py-4 rounded-lg shadow-lg transform translate-x-full transition-transform duration-300 z-50">
     <div class="flex items-center">
       <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,6 +9,15 @@
   
   body {
     @apply antialiased;
+    /* Prevent any stray full-bleed/overflowing element from causing
+       horizontal page scroll on mobile. `clip` (unlike `hidden`) does not
+       create a scroll container, so it keeps `position: sticky` working. */
+    overflow-x: clip;
+  }
+
+  /* Remove the 300ms tap delay and grey flash on touch devices */
+  a, button, [role="button"] {
+    -webkit-tap-highlight-color: transparent;
   }
 }
 


### PR DESCRIPTION
- Header: use dynamic viewport units (dvh/dvw) so the full-screen mobile
  menu is no longer clipped behind browser chrome; make the menu scrollable
  on short screens, respect safe-area insets, enlarge the menu-button touch
  target, and drop a stray console.log.
- Hero: clip decorative blur blobs that could trigger horizontal page
  scroll on mobile, and reduce the oversized base heading (text-6xl ->
  text-5xl) so it fits narrow screens.
- Blog posts: wrap wide Markdown tables in a horizontally scrollable
  container so they no longer overflow the layout on mobile.
- About: smoother responsive ramp for the large kanji display.
- Global: add overflow-x: clip safety net (keeps sticky working) and
  remove the tap-highlight flash on touch devices.