### PR TITLE
fix(ci): use admin PAT for semantic-release pushes + manual trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -19,7 +20,9 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
+        # RELEASE_TOKEN is a fine-grained PAT (Contents: read/write) owned by a
+        # repo admin, so the release commit bypasses the "PR required" ruleset.
+        token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         
     - name: Setup Node.js
       uses: actions/setup-node@v4
@@ -42,5 +45,5 @@ jobs:
       
     - name: Semantic Release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
       run: npx semantic-release


### PR DESCRIPTION
## Why

The Release workflow fails at the `@semantic-release/git` step with **GH013: Changes must be made through a pull request** — the default `GITHUB_TOKEN` can't bypass the `main-rules` ruleset, and the GitHub Actions app isn't selectable as a bypass actor on this repo.

## What

- Use `RELEASE_TOKEN` (fine-grained PAT, Contents/Issues/PRs read-write, owned by a repo admin with *always* bypass) for both checkout and semantic-release, with `GITHUB_TOKEN` fallback
- Add `workflow_dispatch` so a failed release can be retried from the Actions tab without a new commit

Merging this PR triggers the Release workflow on main, which should publish v1.0.0 (changelog commit, tag, GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)