### PR TITLE
fix(ci): stop attaching dist/** as GitHub release assets

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -17,16 +17,6 @@
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
-    [
-      "@semantic-release/github",
-      {
-        "assets": [
-          {
-            "path": "dist/**/*",
-            "name": "umai-tech-${nextRelease.gitTag}-dist.zip"
-          }
-        ]
-      }
-    ]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Problem
The Release workflow fails on the **Semantic Release** step with:

```
RequestError [HttpError]: Validation Failed:
{"resource":"ReleaseAsset","field":"size","message":"size must be greater than or equal to 1"}
```

`@semantic-release/github` was configured with `"path": "dist/**/*"`. That glob matches hundreds of built files, so semantic-release uploads each one individually (the single-zip `name` is ignored for multi-file globs). One of them is **0 bytes**, which GitHub rejects (422), failing the publish step.

Effect: the git tag and `chore(release)` changelog commit still land (they run before the GitHub step), but the GitHub Release never un-drafts — so **every release since v1.0.0 is stuck as a Draft** and the workflow always goes red.

## Fix
The site is deployed by Vercel, so the build doesn't need to be attached to GitHub Releases. Drop the `assets` block; the release becomes tag + notes + changelog, which publishes cleanly and fast.

```diff
-    ["@semantic-release/github", { "assets": [{ "path": "dist/**/*", "name": "...dist.zip" }] }]
+    "@semantic-release/github"
```

(If a dist archive is ever wanted, add a `zip -r dist.zip dist` step before semantic-release and point `path` at that single file instead of a glob.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)